### PR TITLE
Implement user-specific storage directories

### DIFF
--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -335,12 +335,18 @@ async function main() {
       });
       
       if (parentConfig) {
+        if (parentConfig.nostr_nsec_hex) {
+          const hash = crypto.createHash('sha256').update(parentConfig.nostr_nsec_hex).digest('hex');
+          const userDir = join(Pear.config.storage || __dirname, hash);
+          await fs.mkdir(userDir, { recursive: true });
+          parentConfig.storage = userDir;
+        }
         // Merge parent config with loaded config
         config = {
           ...config,
-          ...parentConfig,
-          storage: config.storage // Keep storage path
+          ...parentConfig
         };
+        Pear.config.storage = config.storage;
         console.log('[Worker] Merged config with parent data:', config);
       }
     }


### PR DESCRIPTION
## Summary
- store Hypertuna configuration in per-user directories
- load user configuration in the desktop app using the active user's private key
- propagate user-specific storage path to worker

## Testing
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*
- `npm test` in `hypertuna-worker` *(fails: brittle not found)*