### PR TITLE
Implement relay list management via Nostr kind 10009

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -802,7 +802,9 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             // Get groups from the nostr client - filtered for Hypertuna groups
-            const groups = this.nostr.getGroups();
+            const allGroups = this.nostr.getGroups();
+            const allowedIds = this.nostr.getUserRelayGroupIds();
+            const groups = allGroups.filter(g => allowedIds.includes(g.hypertunaId));
             
             if (groups.length === 0) {
                 groupsList.innerHTML = `
@@ -1354,6 +1356,10 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             await this.nostr.leaveGroup(this.currentGroupId);
+
+            if (window.disconnectRelayInstance && this.currentHypertunaId) {
+                window.disconnectRelayInstance(this.currentHypertunaId);
+            }
             
             // Reload group details to reflect membership changes
             setTimeout(() => {
@@ -1547,6 +1553,10 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             await this.nostr.deleteGroup(this.currentGroupId);
+
+            if (window.disconnectRelayInstance && this.currentHypertunaId) {
+                window.disconnectRelayInstance(this.currentHypertunaId);
+            }
             
             this.closeConfirmationModal();
             alert('Group deletion request sent! The group will be removed once relays process the event.');

--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -54,9 +54,12 @@ class NostrEvents {
     static KIND_GROUP_ADMIN_LIST = 39001;
     static KIND_GROUP_MEMBER_LIST = 39002;
     static KIND_GROUP_ROLES_LIST = 39003;
-    
+
     // Hypertuna custom events
     static KIND_HYPERTUNA_RELAY = 30166;
+
+    // User relay list event
+    static KIND_USER_RELAY_LIST = 10009;
     
     /**
      * Create and sign a generic event with enhanced logging
@@ -489,6 +492,23 @@ class NostrEvents {
             this.KIND_GROUP_DELETE,
             'Deleting group',
             [['h', groupId]],
+            privateKey
+        );
+    }
+
+    /**
+     * Create a user relay list event (kind 10009)
+     * @param {Array} tags - Public relay tags
+     * @param {Array} contentArray - Private relay tags (will be JSON encoded)
+     * @param {string} privateKey - Private key for signing
+     * @returns {Promise<Object>} - Signed event
+     */
+    static async createUserRelayListEvent(tags = [], contentArray = [], privateKey) {
+        const content = JSON.stringify(contentArray);
+        return this.createEvent(
+            this.KIND_USER_RELAY_LIST,
+            content,
+            tags,
             privateKey
         );
     }

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -26,6 +26,9 @@ class NostrGroupClient {
         this.eventCallbacks = []; // Array of callbacks for received events
         this.hypertunaGroups = new Map(); // Map of hypertunaId -> groupId
         this.groupHypertunaIds = new Map(); // Map of groupId -> hypertunaId
+        this.hypertunaRelayUrls = new Map(); // Map of groupId -> relay URL
+        this.userRelayListEvent = null; // latest kind 10009 event
+        this.userRelayIds = new Set(); // Set of hypertuna relay ids user belongs to
         this.debugMode = debugMode;
 
         // Setup default event handlers
@@ -69,6 +72,9 @@ class NostrGroupClient {
         
         // Fetch user's follows
         await this.fetchUserFollows();
+
+        // Fetch or create the user's relay list event
+        await this.fetchUserRelayList();
         
         // Create subscriptions
         this._createSubscriptions();
@@ -231,6 +237,98 @@ class NostrGroupClient {
             });
         });
     }
+
+    /**
+     * Fetch the user's relay list event (kind 10009) or create one if missing
+     */
+    async fetchUserRelayList() {
+        if (!this.user || !this.user.pubkey) return;
+
+        return new Promise((resolve) => {
+            const subId = `relaylist-${this.user.pubkey.substring(0,8)}`;
+            let received = false;
+
+            const timeoutId = setTimeout(async () => {
+                this.relayManager.unsubscribe(subId);
+                if (!received) {
+                    await this._createEmptyRelayList();
+                }
+                resolve();
+            }, 5000);
+
+            this.relayManager.subscribe(subId, [
+                { kinds: [NostrEvents.KIND_USER_RELAY_LIST], authors: [this.user.pubkey], limit: 1 }
+            ], (event) => {
+                received = true;
+                clearTimeout(timeoutId);
+                this.relayManager.unsubscribe(subId);
+                this.userRelayListEvent = event;
+                this._parseRelayListEvent(event);
+                resolve();
+            });
+        });
+    }
+
+    _parseRelayListEvent(event) {
+        this.userRelayIds.clear();
+        if (!event) return;
+        event.tags.forEach(t => {
+            if (t[0] === 'group' && t[1]) this.userRelayIds.add(t[1]);
+        });
+        try {
+            const arr = JSON.parse(event.content || '[]');
+            arr.forEach(t => {
+                if (Array.isArray(t) && t[0] === 'group' && t[1]) this.userRelayIds.add(t[1]);
+            });
+        } catch {}
+    }
+
+    async _createEmptyRelayList() {
+        const event = await NostrEvents.createUserRelayListEvent([], [], this.user.privateKey);
+        await this.relayManager.publish(event);
+        this.userRelayListEvent = event;
+        this.userRelayIds.clear();
+    }
+
+    async updateUserRelayList(relayId, gatewayUrl, isPublic, add = true) {
+        if (!this.userRelayListEvent) {
+            await this._createEmptyRelayList();
+        }
+
+        const tags = [...this.userRelayListEvent.tags];
+        let contentArr;
+        try { contentArr = JSON.parse(this.userRelayListEvent.content || '[]'); } catch { contentArr = []; }
+
+        const groupTag = ['group', relayId, `${gatewayUrl}/${relayId}`];
+        const rTag = ['r', `${gatewayUrl}/${relayId}`];
+
+        const remove = (arr, tag) => {
+            const idx = arr.findIndex(t => JSON.stringify(t) === JSON.stringify(tag));
+            if (idx > -1) arr.splice(idx,1);
+        };
+
+        if (add) {
+            if (isPublic) {
+                tags.push(groupTag, rTag);
+            } else {
+                contentArr.push(groupTag, rTag);
+            }
+            this.userRelayIds.add(relayId);
+        } else {
+            if (isPublic) {
+                remove(tags, groupTag);
+                remove(tags, rTag);
+            } else {
+                remove(contentArr, groupTag);
+                remove(contentArr, rTag);
+            }
+            this.userRelayIds.delete(relayId);
+        }
+
+        const newEvent = await NostrEvents.createUserRelayListEvent(tags, contentArr, this.user.privateKey);
+        this.userRelayListEvent = newEvent;
+        await this.relayManager.publish(newEvent);
+    }
     
     /**
      * Determine if an event should be processed based on relevance
@@ -357,6 +455,15 @@ class NostrGroupClient {
             this._processHypertunaRelayEvent(event);
         });
         this.activeSubscriptions.add(hypertunaRelaySubId);
+
+        // Subscribe to user's relay list (kind 10009)
+        const relayListSub = this.relayManager.subscribe('user-relaylist', [
+            { kinds: [NostrEvents.KIND_USER_RELAY_LIST], authors: [this.user.pubkey], limit: 1 }
+        ], (event) => {
+            this.userRelayListEvent = event;
+            this._parseRelayListEvent(event);
+        });
+        this.activeSubscriptions.add(relayListSub);
         
         // Subscribe to group membership changes affecting user
         const membershipSubId = this.relayManager.subscribe('user-groups', [
@@ -503,6 +610,11 @@ class NostrGroupClient {
             case NostrEvents.KIND_HYPERTUNA_RELAY:
                 this._processHypertunaRelayEvent(event);
                 break;
+
+            case NostrEvents.KIND_USER_RELAY_LIST:
+                this.userRelayListEvent = event;
+                this._parseRelayListEvent(event);
+                break;
         }
         
         // Emit event for any listeners
@@ -639,6 +751,11 @@ class NostrGroupClient {
         if (!groupId) {
             console.warn('Hypertuna relay event missing h tag');
             return;
+        }
+
+        const relayUrl = NostrEvents._getTagValue(event, 'd');
+        if (relayUrl) {
+            this.hypertunaRelayUrls.set(groupId, relayUrl);
         }
         
         console.log(`Processing Hypertuna relay event for group ${groupId} with hypertuna ID ${hypertunaId}`);
@@ -1011,6 +1128,10 @@ class NostrGroupClient {
     getGroupMessages(groupId) {
         return this.groupMessages.get(groupId) || [];
     }
+
+    getUserRelayGroupIds() {
+        return Array.from(this.userRelayIds);
+    }
     
     /**
      * Create a new group
@@ -1054,13 +1175,18 @@ class NostrGroupClient {
             normalizedData.proxyServer
         );
         
-        const { 
-            groupCreateEvent, 
-            metadataEvent, 
-            hypertunaEvent, 
-            groupId, 
-            hypertunaId 
+        const {
+            groupCreateEvent,
+            metadataEvent,
+            hypertunaEvent,
+            groupId,
+            hypertunaId
         } = eventsCollection;
+
+        const relayUrl = NostrEvents._getTagValue(hypertunaEvent, 'd');
+        if (relayUrl) {
+            this.hypertunaRelayUrls.set(groupId, relayUrl);
+        }
         
         console.log(`Creating new group with ID: ${groupId}`);
         console.log(`Using Hypertuna ID: ${hypertunaId}`);
@@ -1142,7 +1268,11 @@ class NostrGroupClient {
         
         // Subscribe to this group
         this.subscribeToGroup(groupId);
-        
+
+        if (relayUrl) {
+            await this.updateUserRelayList(hypertunaId, relayUrl, normalizedData.isPublic, true);
+        }
+
         return eventsCollection;
     }
     
@@ -1168,7 +1298,15 @@ class NostrGroupClient {
         
         // Add this group to subscriptions
         this.subscribeToGroup(groupId);
-        
+
+        const hypertunaId = this.groupHypertunaIds.get(groupId);
+        const relayUrl = this.hypertunaRelayUrls.get(groupId) || '';
+        const group = this.groups.get(groupId);
+        const isPublic = group ? group.isPublic : true;
+        if (hypertunaId && relayUrl) {
+            await this.updateUserRelayList(hypertunaId, relayUrl, isPublic, true);
+        }
+
         return event;
     }
     
@@ -1192,7 +1330,15 @@ class NostrGroupClient {
         
         // Remove this group from subscriptions
         this.unsubscribeFromGroup(groupId);
-        
+
+        const hypertunaId = this.groupHypertunaIds.get(groupId);
+        const relayUrl = this.hypertunaRelayUrls.get(groupId) || '';
+        const group = this.groups.get(groupId);
+        const isPublic = group ? group.isPublic : true;
+        if (hypertunaId && relayUrl) {
+            await this.updateUserRelayList(hypertunaId, relayUrl, isPublic, false);
+        }
+
         return event;
     }
     
@@ -1401,10 +1547,18 @@ class NostrGroupClient {
         
         // Publish the event
         await this.relayManager.publish(event);
-        
+
         // Remove subscriptions for this group
         this.unsubscribeFromGroup(groupId);
-        
+
+        const hypertunaId = this.groupHypertunaIds.get(groupId);
+        const relayUrl = this.hypertunaRelayUrls.get(groupId) || '';
+        const group = this.groups.get(groupId);
+        const isPublic = group ? group.isPublic : true;
+        if (hypertunaId && relayUrl) {
+            await this.updateUserRelayList(hypertunaId, relayUrl, isPublic, false);
+        }
+
         return event;
     }
     
@@ -1456,6 +1610,9 @@ class NostrGroupClient {
         this.relevantPubkeys.clear();
         this.hypertunaGroups.clear();
         this.groupHypertunaIds.clear();
+        this.hypertunaRelayUrls.clear();
+        this.userRelayIds.clear();
+        this.userRelayListEvent = null;
         
         // Clear event listeners
         this.eventListeners.clear();

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -250,6 +250,10 @@ class NostrIntegration {
     getGroupMessages(groupId) {
         return this.client.getGroupMessages(groupId);
     }
+
+    getUserRelayGroupIds() {
+        return this.client.getUserRelayGroupIds();
+    }
     
     /**
      * Create a new group

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -956,6 +956,7 @@ console.log('[App] Exposing window functions');
 window.startWorker = startWorker;
 window.stopWorker = stopWorker;
 window.createRelayInstance = createRelayInstance;
+window.disconnectRelayInstance = disconnectRelay;
 window.debugButtonState = debugButtonState;
 
 console.log('[App] app.js loading completed at:', new Date().toISOString());


### PR DESCRIPTION
## Summary
- support user relay list events (kind 10009)
- track relay membership in `NostrGroupClient`
- expose relay disconnect function in app.js
- show only relays that appear in the user relay list
- update relay list when creating, joining or leaving a relay

## Testing
- `npm test` (fails: brittle not found)


------
https://chatgpt.com/codex/tasks/task_e_683bdbc9b43c832ab27e24c4a6bbb1e5