### PR TITLE
Implement relay list management via Nostr kind 10009

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -802,7 +802,9 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             // Get groups from the nostr client - filtered for Hypertuna groups
-            const groups = this.nostr.getGroups();
+            const allGroups = this.nostr.getGroups();
+            const allowedIds = this.nostr.getUserRelayGroupIds();
+            const groups = allGroups.filter(g => allowedIds.includes(g.hypertunaId));
             
             if (groups.length === 0) {
                 groupsList.innerHTML = `
@@ -1354,6 +1356,10 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             await this.nostr.leaveGroup(this.currentGroupId);
+
+            if (window.disconnectRelayInstance && this.currentHypertunaId) {
+                window.disconnectRelayInstance(this.currentHypertunaId);
+            }
             
             // Reload group details to reflect membership changes
             setTimeout(() => {
@@ -1547,6 +1553,10 @@ App.syncHypertunaConfigToFile = async function() {
         
         try {
             await this.nostr.deleteGroup(this.currentGroupId);
+
+            if (window.disconnectRelayInstance && this.currentHypertunaId) {
+                window.disconnectRelayInstance(this.currentHypertunaId);
+            }
             
             this.closeConfirmationModal();
             alert('Group deletion request sent! The group will be removed once relays process the event.');

--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -54,9 +54,12 @@ class NostrEvents {
     static KIND_GROUP_ADMIN_LIST = 39001;
     static KIND_GROUP_MEMBER_LIST = 39002;
     static KIND_GROUP_ROLES_LIST = 39003;
-    
+
     // Hypertuna custom events
     static KIND_HYPERTUNA_RELAY = 30166;
+
+    // User relay list event
+    static KIND_USER_RELAY_LIST = 10009;
     
     /**
      * Create and sign a generic event with enhanced logging
@@ -489,6 +492,28 @@ class NostrEvents {
             this.KIND_GROUP_DELETE,
             'Deleting group',
             [['h', groupId]],
+            privateKey
+        );
+    }
+
+    /**
+     * Create a user relay list event (kind 10009)
+     * @param {Array} tags - Public relay tags
+     * @param {Array} contentArray - Private relay tags (will be JSON encoded)
+     * @param {string} privateKey - Private key for signing
+     * @returns {Promise<Object>} - Signed event
+     */
+    static async createUserRelayListEvent(tags = [], contentArray = [], privateKey) {
+        let content = '';
+        if (Array.isArray(contentArray) && contentArray.length > 0) {
+            const json = JSON.stringify(contentArray);
+            const pubkey = NostrUtils.getPublicKey(privateKey);
+            content = NostrUtils.encrypt(privateKey, pubkey, json);
+        }
+        return this.createEvent(
+            this.KIND_USER_RELAY_LIST,
+            content,
+            tags,
             privateKey
         );
     }

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -250,6 +250,10 @@ class NostrIntegration {
     getGroupMessages(groupId) {
         return this.client.getGroupMessages(groupId);
     }
+
+    getUserRelayGroupIds() {
+        return this.client.getUserRelayGroupIds();
+    }
     
     /**
      * Create a new group

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -956,6 +956,7 @@ console.log('[App] Exposing window functions');
 window.startWorker = startWorker;
 window.stopWorker = stopWorker;
 window.createRelayInstance = createRelayInstance;
+window.disconnectRelayInstance = disconnectRelay;
 window.debugButtonState = debugButtonState;
 
 console.log('[App] app.js loading completed at:', new Date().toISOString());


### PR DESCRIPTION
## Summary
- support user relay list events (kind 10009)
- track relay membership in `NostrGroupClient`
- expose relay disconnect function in app.js
- show only relays that appear in the user relay list
- update relay list when creating, joining or leaving a relay
- encrypt private relay references per NIP-51

## Testing
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*
- `npm test` in `hypertuna-worker` *(fails: brittle not found)*


------
https://chatgpt.com/codex/tasks/task_e_683bdbc9b43c832ab27e24c4a6bbb1e5