### PR TITLE
Fix groups list spinner on returning user launch

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1659,6 +1659,9 @@ App.syncHypertunaConfigToFile = async function() {
 
     // Initialize nostr integration if user is already logged in AND hasn't explicitly logged out
     if (App.currentUser && App.currentUser.privateKey && !explicitLogout) {
+        // Show a spinner while the groups list is being restored
+        App.showGroupListSpinner();
+
         // Generate Hypertuna configuration if it doesn't exist
         if (!App.currentUser.hypertunaConfig) {
             (async () => {
@@ -1686,6 +1689,9 @@ App.syncHypertunaConfigToFile = async function() {
                 // Connect to relays
                 await App.nostr.connectRelay();
                 console.log('Connected to default relays for returning user');
+
+                // Refresh the groups list once relays have connected
+                App.loadGroups();
                 
                 // Start worker if available
                 if (window.startWorker) {


### PR DESCRIPTION
## Summary
- show spinner and refresh groups when initializing nostr for saved sessions

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9aee7228832abd3687f40e3c1cd5