### PR TITLE
Fix groups page loading spinner and EOSE handling

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -125,7 +125,9 @@ function integrateNostrRelays(App) {
             
             // Connect to relay if not already connected
             if ((!this.relay || !this.relay.isConnected()) && this.nostr) {
-                this.connectRelay();
+                await this.connectRelay();
+                await this.nostr.client.waitForGroupListReady();
+                this.loadGroups();
             } else {
                 this.updateUIState();
             }
@@ -1659,6 +1661,9 @@ App.syncHypertunaConfigToFile = async function() {
 
     // Initialize nostr integration if user is already logged in AND hasn't explicitly logged out
     if (App.currentUser && App.currentUser.privateKey && !explicitLogout) {
+        // Show a spinner while the groups list is being restored
+        App.showGroupListSpinner();
+
         // Generate Hypertuna configuration if it doesn't exist
         if (!App.currentUser.hypertunaConfig) {
             (async () => {
@@ -1686,6 +1691,10 @@ App.syncHypertunaConfigToFile = async function() {
                 // Connect to relays
                 await App.nostr.connectRelay();
                 console.log('Connected to default relays for returning user');
+
+                // Wait until group data is ready before refreshing the list
+                await App.nostr.client.waitForGroupListReady();
+                App.loadGroups();
                 
                 // Start worker if available
                 if (window.startWorker) {

--- a/hypertuna-desktop/WebSocketRelayManager.js
+++ b/hypertuna-desktop/WebSocketRelayManager.js
@@ -616,8 +616,26 @@ async testPublish() {
         }
         else if (messageType === 'EOSE') {
             // ["EOSE", <subscription_id>]
-            // End of stored events, we could notify listeners if needed
-            // console.log(`End of stored events for subscription ${message[1]} from ${relayUrl}`);
+            const shortSubId = message[1];
+            let originalSubId = null;
+            this.globalSubscriptions.forEach((subData, subId) => {
+                if (subData.shortId === shortSubId) {
+                    originalSubId = subId;
+                }
+            });
+
+            if (!originalSubId) return;
+
+            const subscription = this.globalSubscriptions.get(originalSubId);
+            if (subscription) {
+                subscription.callbacks.forEach(callback => {
+                    try {
+                        callback(null, relayUrl, originalSubId, true);
+                    } catch (e) {
+                        console.error('Error in subscription callback:', e);
+                    }
+                });
+            }
         }
         else if (messageType === 'NOTICE') {
             // ["NOTICE", <message>]


### PR DESCRIPTION
## Summary
- wait for group subscriptions to reach EOSE before refreshing groups
- show groups once initial events arrive or when all subscriptions finish

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9aee7228832abd3687f40e3c1cd5