### PR TITLE
Fix redundant relay connection

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -811,8 +811,12 @@ App.syncHypertunaConfigToFile = async function() {
 
         const groupsList = document.getElementById('groups-list');
         this.showGroupListSpinner();
-        
+
         try {
+            if (!this.nostr.areRelayIdsReady()) {
+                groupsList.innerHTML = '<div class="status-message">Loading relay data...</div>';
+                return;
+            }
             // Get groups from the nostr client - filtered for Hypertuna groups
             const allGroups = this.nostr.getGroups();
             const allowedIds = this.nostr.getUserRelayGroupIds();
@@ -1686,9 +1690,14 @@ App.syncHypertunaConfigToFile = async function() {
                     'wss://nos.lol'
                 ];
                 
-                // Connect to relays
-                await App.nostr.connectRelay();
-                console.log('Connected to default relays for returning user');
+
+
+                // Ensure relays are connected
+                if (!App.nostr.client.relayManager.getRelays().some(url =>
+                        App.nostr.client.relayManager.getRelayStatus(url) === 'open')) {
+                    await App.nostr.connectRelay();
+                    console.log('Connected to default relays for returning user');
+                }
 
                 // Refresh the groups list once relays have connected
                 App.loadGroups();

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -29,6 +29,7 @@ class NostrGroupClient {
         this.hypertunaRelayUrls = new Map(); // Map of groupId -> relay URL
         this.userRelayListEvent = null; // latest kind 10009 event
         this.userRelayIds = new Set(); // Set of hypertuna relay ids user belongs to
+        this.relayListLoaded = false; // flag indicating relay list has been parsed
         this.debugMode = debugMode;
 
         // Setup default event handlers
@@ -300,8 +301,9 @@ class NostrGroupClient {
                 });
             } catch {}
         }
-
+        this.relayListLoaded = true;
         console.log('Parsed relay list. Current user relay IDs:', Array.from(this.userRelayIds));
+        this.emit('relaylist:update', { ids: Array.from(this.userRelayIds) });
     }
 
     async _createEmptyRelayList() {
@@ -309,6 +311,8 @@ class NostrGroupClient {
         await this.relayManager.publish(event);
         this.userRelayListEvent = event;
         this.userRelayIds.clear();
+        this.relayListLoaded = true;
+        this.emit('relaylist:update', { ids: Array.from(this.userRelayIds) });
         console.log('Created empty user relay list event');
     }
 
@@ -1167,6 +1171,10 @@ class NostrGroupClient {
 
     getUserRelayGroupIds() {
         return Array.from(this.userRelayIds).filter(Boolean);
+    }
+
+    isRelayListReady() {
+        return this.relayListLoaded;
     }
     
     /**

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -1126,12 +1126,6 @@
             setTimeout(async () => {
                 console.log('[Index] Auto-connecting for returning user...');
                 try {
-                    // Connect to relays
-                    if (App.nostr && App.nostr.client) {
-                        await App.nostr.connectRelay();
-                        console.log('[Index] Connected to relays');
-                    }
-                    
                     // Start worker if available
                     if (window.startWorker) {
                       const key = await window.startWorker();


### PR DESCRIPTION
## Summary
- avoid unnecessary connectRelay call when returning users autoconnect
- guard against already-connected relays before attempting connection

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd hypertuna-desktop && npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbdab51e4832aad8cb046c3705130