### PR TITLE
Implement per-relay message throttling

### DIFF
--- a/hypertuna-desktop/WebSocketRelayManager.js
+++ b/hypertuna-desktop/WebSocketRelayManager.js
@@ -11,11 +11,8 @@ class WebSocketRelayManager {
         this.connectCallbacks = []; // Callbacks for relay connections
         this.disconnectCallbacks = []; // Callbacks for relay disconnections
         
-        // Add rate limiting
-        this.requestQueue = [];
-        this.processingQueue = false;
-        this.lastRequestTime = 0;
-        this.minTimeBetweenRequests = 50; // 50ms between requests to avoid "too fast" errors
+        // Rate limiting between messages for each relay
+        this.minTimeBetweenRequests = 250; // ms between messages per relay
     }
 
     /**
@@ -41,7 +38,10 @@ class WebSocketRelayManager {
                     conn: ws,
                     status: 'connecting',
                     subscriptions: new Map(),
-                    pendingMessages: []
+                    pendingMessages: [],
+                    requestQueue: [],
+                    processingQueue: false,
+                    lastRequestTime: 0
                 };
                 
                 this.relays.set(url, relayData);
@@ -53,7 +53,7 @@ class WebSocketRelayManager {
                     // Send any pending messages with rate limiting
                     if (relayData.pendingMessages.length > 0) {
                         relayData.pendingMessages.forEach(msg => {
-                            this._queueRequest(() => {
+                            this._queueRelayRequest(url, () => {
                                 if (ws.readyState === WebSocket.OPEN) {
                                     ws.send(msg);
                                 }
@@ -116,41 +116,43 @@ class WebSocketRelayManager {
     }
 
     /**
-     * Process the request queue with rate limiting
+     * Process the queue for a specific relay with rate limiting
+     * @param {string} relayUrl - Relay identifier
      * @private
      */
-    _processQueue() {
-        if (this.requestQueue.length === 0) {
-            this.processingQueue = false;
+    _processRelayQueue(relayUrl) {
+        const relay = this.relays.get(relayUrl);
+        if (!relay) return;
+
+        if (relay.requestQueue.length === 0) {
+            relay.processingQueue = false;
             return;
         }
 
-        this.processingQueue = true;
+        relay.processingQueue = true;
         const now = Date.now();
-        const timeSinceLastRequest = now - this.lastRequestTime;
-        
-        // If we need to wait, schedule the next request
-        if (timeSinceLastRequest < this.minTimeBetweenRequests) {
-            setTimeout(() => this._processQueue(), 
-                this.minTimeBetweenRequests - timeSinceLastRequest);
+        const timeSinceLast = now - relay.lastRequestTime;
+
+        if (timeSinceLast < this.minTimeBetweenRequests) {
+            setTimeout(() => this._processRelayQueue(relayUrl),
+                this.minTimeBetweenRequests - timeSinceLast);
             return;
         }
 
-        // Process the next request
-        const request = this.requestQueue.shift();
-        this.lastRequestTime = Date.now();
-        
+        const request = relay.requestQueue.shift();
+        relay.lastRequestTime = Date.now();
+
         try {
             request();
         } catch (e) {
-            console.error('Error processing request:', e);
+            console.error(`Error processing request for ${relayUrl}:`, e);
         }
 
-        // Continue processing queue if there are more items
-        if (this.requestQueue.length > 0) {
-            setTimeout(() => this._processQueue(), this.minTimeBetweenRequests);
+        if (relay.requestQueue.length > 0) {
+            setTimeout(() => this._processRelayQueue(relayUrl),
+                this.minTimeBetweenRequests);
         } else {
-            this.processingQueue = false;
+            relay.processingQueue = false;
         }
     }
 
@@ -189,11 +191,14 @@ _validateEvent(event) {
      * @param {Function} request - Function to execute
      * @private
      */
-    _queueRequest(request) {
-        this.requestQueue.push(request);
-        
-        if (!this.processingQueue) {
-            this._processQueue();
+    _queueRelayRequest(relayUrl, request) {
+        const relay = this.relays.get(relayUrl);
+        if (!relay) return;
+
+        relay.requestQueue.push(request);
+
+        if (!relay.processingQueue) {
+            this._processRelayQueue(relayUrl);
         }
     }
 
@@ -321,8 +326,8 @@ _validateEvent(event) {
         const reqMsg = JSON.stringify(['REQ', shortSubId, ...filters]);
         console.log(`REQ message to ${relayUrl}:`, reqMsg);
         
-        // Queue the subscription request
-        this._queueRequest(() => {
+        // Queue the subscription request for this relay
+        this._queueRelayRequest(relayUrl, () => {
             if (relay.status === 'open') {
                 relay.conn.send(reqMsg);
                 console.log(`Subscription ${shortSubId} sent to ${relayUrl}`);
@@ -356,7 +361,7 @@ _validateEvent(event) {
             if (relay.status === 'open' && relay.subscriptions.has(subscriptionId)) {
                 const closeMsg = JSON.stringify(['CLOSE', shortSubId]);
                 
-                this._queueRequest(() => {
+                this._queueRelayRequest(url, () => {
                     if (relay.status === 'open') {
                         relay.conn.send(closeMsg);
                     }
@@ -447,8 +452,8 @@ _validateEvent(event) {
                         // Listen for the OK response
                         relay.conn.addEventListener('message', okHandler);
                         
-                        // Queue the publish request
-                        this._queueRequest(() => {
+                        // Queue the publish request for this relay
+                        this._queueRelayRequest(url, () => {
                             try {
                                 if (relay.conn.readyState === WebSocket.OPEN) {
                                     relay.conn.send(eventMsg);


### PR DESCRIPTION
## Summary
- add per-relay request queues in `WebSocketRelayManager`
- queue pending messages, subscriptions, and publishes using the per-relay queue
- increase delay between messages to 250ms to reduce relay rate-limits

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d2e157f6c832aaa922f37f6944987