### PR TITLE
Fix 'Your Relays' list stale items

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1671,6 +1671,8 @@ App.switchListView = function(view) {
     if (view === 'your') {
         groupsList.classList.remove('hidden');
         discoverList.classList.add('hidden');
+        // Clear any previously discovered relays to avoid stale items
+        discoverList.innerHTML = '';
         this.loadGroups();
     } else {
         groupsList.classList.add('hidden');

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1260,26 +1260,22 @@ async fetchMultipleProfiles(pubkeys) {
             console.log('No groups found in the map');
         }
         
-        // For debugging, return all groups regardless of filters
+        // Early return if we have no groups cached
         if (allGroups.length === 0) {
-            console.log('Returning all groups for debugging');
+            console.log('Returning empty group list');
             return allGroups;
         }
-        
+
         // Filter for Hypertuna groups using the identifier tag
         const hypertunaGroups = allGroups.filter(group => {
-            // Check if this is a Hypertuna relay group using the identifier tag
-            const isHypertunaRelay = group.isHypertunaRelay || 
-                                  (group.event && group.event.tags.some(tag => 
-                                      tag[0] === 'i' && tag[1] === 'hypertuna:relay'));
-            
-            // Check if it has a hypertuna ID
+            const isHypertunaRelay = group.isHypertunaRelay ||
+                (group.event && group.event.tags.some(tag => tag[0] === 'i' && tag[1] === 'hypertuna:relay'));
+
             const hasHypertunaId = !!group.hypertunaId;
-            
+
             console.log(`Group ${group.id}: isHypertunaRelay=${isHypertunaRelay}, hasHypertunaId=${hasHypertunaId}`);
-            
-            // For debugging, include all groups to see what's available
-            return true;
+
+            return isHypertunaRelay && hasHypertunaId;
         });
         
         console.log(`Filtered groups: ${hypertunaGroups.length}`);


### PR DESCRIPTION
## Summary
- properly filter Hypertuna groups in `NostrGroupClient.getGroups`
- clear cached Discover list when switching back to Your Relays

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e2dd57538832ab9bd0eec50f5429c