### PR TITLE
Add npub display and relay tagging

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1199,6 +1199,8 @@ App.syncHypertunaConfigToFile = async function() {
             messages.forEach(message => {
                 const author = profiles[message.pubkey] || { name: 'User_' + NostrUtils.truncatePubkey(message.pubkey) };
                 const isCurrentUser = message.pubkey === this.currentUser.pubkey;
+                const npub = NostrUtils.hexToNpub(message.pubkey);
+                const displayPub = NostrUtils.truncateNpub(npub);
                 
                 const messageElement = document.createElement('div');
                 messageElement.className = `message ${isCurrentUser ? 'own' : ''}`;
@@ -1209,6 +1211,7 @@ App.syncHypertunaConfigToFile = async function() {
                     </div>
                     <div class="message-meta">
                         <span>${author.name || 'Unknown'}</span>
+                        <span class="message-pubkey">${displayPub}</span>
                         <span>${this.formatTime(message.created_at)}</span>
                     </div>
                 `;
@@ -1290,6 +1293,8 @@ App.syncHypertunaConfigToFile = async function() {
                 const profile = profiles[pubkey] || {};
                 const roles = memberRoles[pubkey] || ['member'];
                 const isCurrentUser = pubkey === this.currentUser.pubkey;
+                const npub = NostrUtils.hexToNpub(pubkey);
+                const displayPub = NostrUtils.truncateNpub(npub);
                 
                 const memberElement = document.createElement('div');
                 memberElement.className = 'member-item';
@@ -1308,7 +1313,7 @@ App.syncHypertunaConfigToFile = async function() {
                     </div>
                     <div class="member-info">
                         <div class="member-name">${name}</div>
-                        <div class="member-pubkey">${NostrUtils.truncatePubkey(pubkey)}</div>
+                        <div class="member-pubkey">${displayPub}</div>
                     </div>
                     <span class="member-role ${roleClass}">${roleText}</span>
                 `;
@@ -2089,13 +2094,16 @@ App.loadFollowingList = async function() {
                 avatarHtml = `<span>${firstLetter}</span>`;
             }
             
+            const npub = NostrUtils.hexToNpub(pubkey);
+            const displayPub = NostrUtils.truncateNpub(npub);
+
             followItem.innerHTML = `
                 <div class="following-avatar">
                     ${avatarHtml}
                 </div>
                 <div class="following-info">
                     <div class="following-name">${name}</div>
-                    <div class="following-pubkey">${NostrUtils.truncatePubkey(pubkey)}</div>
+                    <div class="following-pubkey">${displayPub}</div>
                 </div>
                 <button class="btn-remove" data-pubkey="${pubkey}">Remove</button>
             `;
@@ -2181,13 +2189,16 @@ App.addFollow = async function() {
             avatarHtml = `<span>${firstLetter}</span>`;
         }
         
+        const npubAdded = NostrUtils.hexToNpub(pubkey);
+        const displayPubAdded = NostrUtils.truncateNpub(npubAdded);
+
         followItem.innerHTML = `
             <div class="following-avatar">
                 ${avatarHtml}
             </div>
             <div class="following-info">
                 <div class="following-name">${name}</div>
-                <div class="following-pubkey">${NostrUtils.truncatePubkey(pubkey)}</div>
+                <div class="following-pubkey">${displayPubAdded}</div>
             </div>
             <button class="btn-remove" data-pubkey="${pubkey}">Remove</button>
         `;

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1798,6 +1798,7 @@ async fetchMultipleProfiles(pubkeys) {
                 `Admin list for group: ${groupData.name}`,
                 [
                     ['d', groupId],
+                    ['hypertuna', groupId],
                     ['p', this.user.pubkey, 'admin']
                 ],
                 this.user.privateKey
@@ -1809,6 +1810,7 @@ async fetchMultipleProfiles(pubkeys) {
                 `Member list for group: ${groupData.name}`,
                 [
                     ['d', groupId],
+                    ['hypertuna', groupId],
                     ['p', this.user.pubkey, 'member']
                 ],
                 this.user.privateKey

--- a/hypertuna-desktop/NostrUtils.js
+++ b/hypertuna-desktop/NostrUtils.js
@@ -227,6 +227,16 @@ export class NostrUtils {
         if (!pubkey) return '';
         return pubkey.substring(0, 6) + '...' + pubkey.substring(pubkey.length - 4);
     }
+
+    /**
+     * Truncate npub for display
+     * @param {string} npub - bech32 public key
+     * @returns {string}
+     */
+    static truncateNpub(npub) {
+        if (!npub) return '';
+        return npub.substring(0, 8) + '...' + npub.substring(npub.length - 4);
+    }
     
     /**
      * Generate a random ID (for group IDs, etc.)

--- a/hypertuna-desktop/styles.css
+++ b/hypertuna-desktop/styles.css
@@ -801,6 +801,15 @@ body {
     white-space: nowrap;
 }
 
+.message-pubkey {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .member-role {
     margin-left: auto;
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- tag admin/member list events with group public identifier
- add helper to shorten bech32 keys
- show npub keys for members, follows and messages
- style message pubkey label

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852269b9a38832a80cf4f6a31ecbcac