### PR TITLE
Maintain relay members map

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -142,7 +142,20 @@ export async function saveRelayProfile(relayProfile) {
         console.log(`[ProfileManager] Writing ${profiles.length} profiles to ${profilesPath}`);
         await fs.writeFile(profilesPath, JSON.stringify({ relays: profiles }, null, 2));
         console.log(`[ProfileManager] Successfully saved relay profile for ${relayProfile.relay_key}`);
-        
+
+        // Update in-memory relay members map in adapter
+        try {
+            const { setRelayMembers } = await import('./hypertuna-relay-manager-adapter.mjs');
+            if (relayProfile.members) {
+                setRelayMembers(relayProfile.relay_key, relayProfile.members);
+                if (relayProfile.public_identifier) {
+                    setRelayMembers(relayProfile.public_identifier, relayProfile.members);
+                }
+            }
+        } catch (err) {
+            console.error('[ProfileManager] Failed to update relayMembers map:', err);
+        }
+
         return true;
     } catch (error) {
         console.error(`[ProfileManager] Error saving relay profile:`, error);


### PR DESCRIPTION
## Summary
- keep in-memory relayMembers map inside worker adapter
- load members when relays are created or joined
- sync the members map whenever profiles are saved

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bc7875d4832a85118c6336a0f57e