### PR TITLE
Add relay member sync

### DIFF
--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -129,6 +129,16 @@ class NostrIntegration {
         this.client.on('group:members', ({ groupId, members }) => {
             console.log(`Updated group members for: ${groupId}`);
             this._throttledGroupUpdate();
+
+            if (window.workerPipe) {
+                const relayKey = this.client.publicToInternalMap?.get(groupId) || groupId;
+                const msg = { type: 'update-members', relayKey, members };
+                try {
+                    window.workerPipe.write(JSON.stringify(msg) + '\n');
+                } catch (err) {
+                    console.error('Failed to send update-members message:', err);
+                }
+            }
         });
         
         this.client.on('group:admins', ({ groupId, admins }) => {

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -146,6 +146,7 @@ async function startWorker() {
         
         // Start the worker process
         workerPipe = Pear.worker.run(workerLink, [])
+        window.workerPipe = workerPipe
         
         // IMPORTANT: Get the current user's config from localStorage instead of file
         let configToUse = {}

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -9,6 +9,11 @@ import process from 'bare-process'
 import { promises as fs } from 'bare-fs'
 import { join } from 'bare-path'
 import crypto from 'bare-crypto'
+import {
+  getAllRelayProfiles,
+  getRelayProfileByKey,
+  saveRelayProfile
+} from './hypertuna-relay-profile-manager-bare.mjs'
 
 // In Pear, use the config.dir for the application directory
 const __dirname = Pear.config.dir || '.'
@@ -16,6 +21,8 @@ const __dirname = Pear.config.dir || '.'
 // Variable to store the relay server module
 let relayServer = null
 let isShuttingDown = false
+// Map of relayKey -> members array
+const relayMembers = new Map()
 
 
 function getUserKey(config) {
@@ -77,6 +84,21 @@ async function loadOrCreateConfig() {
   }
 }
 
+// Load member lists from saved relay profiles
+async function loadRelayMembers() {
+  try {
+    const profiles = await getAllRelayProfiles(global.userConfig?.userKey)
+    for (const profile of profiles) {
+      if (profile.relay_key && Array.isArray(profile.members)) {
+        relayMembers.set(profile.relay_key, profile.members)
+      }
+    }
+    console.log(`[Worker] Loaded members for ${relayMembers.size} relays`)
+  } catch (err) {
+    console.error('[Worker] Failed to load relay members:', err)
+  }
+}
+
 // Handle worker communication
 const workerPipe = Pear.worker.pipe()
 console.log('[Worker] Pipe object:', workerPipe ? 'exists' : 'null')
@@ -94,6 +116,13 @@ const sendMessage = (message) => {
   } else {
     console.log('[Worker] Cannot send message - pipe:', workerPipe ? 'exists' : 'null', 'shuttingDown:', isShuttingDown)
   }
+}
+
+function addMembersToRelays(relays) {
+  return relays.map(r => ({
+    ...r,
+    members: relayMembers.get(r.relayKey) || []
+  }))
 }
 
 // Make pipe and sendMessage globally available for the relay server
@@ -157,17 +186,20 @@ if (workerPipe) {
                 try {
                   // Call the relay server's create relay function
                   const result = await relayServer.createRelay(message.data)
-                  
+
                   sendMessage({
                     type: 'relay-created',
-                    data: result
+                    data: {
+                      ...result,
+                      members: relayMembers.get(result.relayKey) || []
+                    }
                   })
-                  
+
                   // Send updated relay list
                   const relays = await relayServer.getActiveRelays()
                   sendMessage({
                     type: 'relay-update',
-                    relays: relays
+                    relays: addMembersToRelays(relays)
                   })
                 } catch (err) {
                   sendMessage({
@@ -189,17 +221,20 @@ if (workerPipe) {
                 try {
                   // Call the relay server's join relay function
                   const result = await relayServer.joinRelay(message.data)
-                  
+
                   sendMessage({
                     type: 'relay-joined',
-                    data: result
+                    data: {
+                      ...result,
+                      members: relayMembers.get(result.relayKey) || []
+                    }
                   })
-                  
+
                   // Send updated relay list
                   const relays = await relayServer.getActiveRelays()
                   sendMessage({
                     type: 'relay-update',
-                    relays: relays
+                    relays: addMembersToRelays(relays)
                   })
                 } catch (err) {
                   sendMessage({
@@ -226,13 +261,31 @@ if (workerPipe) {
                   const relays = await relayServer.getActiveRelays()
                   sendMessage({
                     type: 'relay-update',
-                    relays: relays
+                    relays: addMembersToRelays(relays)
                   })
                 } catch (err) {
                   sendMessage({
                     type: 'error',
                     message: `Failed to disconnect relay: ${err.message}`
                   })
+                }
+              }
+              break
+
+            case 'update-members':
+              if (message.relayKey) {
+                console.log(`[Worker] Updating members for relay ${message.relayKey}`)
+                relayMembers.set(message.relayKey, message.members || [])
+                try {
+                  let profile = await getRelayProfileByKey(message.relayKey)
+                  if (!profile) profile = { relay_key: message.relayKey }
+                  profile.members = message.members || []
+                  profile.updated_at = new Date().toISOString()
+                  await saveRelayProfile(profile)
+                  sendMessage({ type: 'members-updated', relayKey: message.relayKey })
+                } catch (err) {
+                  console.error('[Worker] Failed to save members:', err)
+                  sendMessage({ type: 'members-updated', relayKey: message.relayKey, error: err.message })
                 }
               }
               break
@@ -245,7 +298,7 @@ if (workerPipe) {
                   const relays = await relayServer.getActiveRelays()
                   sendMessage({
                     type: 'relay-update',
-                    relays: relays
+                    relays: addMembersToRelays(relays)
                   })
                 } catch (err) {
                   sendMessage({
@@ -384,8 +437,10 @@ async function main() {
             userKey: config.userKey,
             storage: config.storage
         };
-        
+
         console.log('[Worker] Set global user config for profile operations');
+
+        await loadRelayMembers();
       }
     }
     


### PR DESCRIPTION
## Summary
- expose workerPipe for use in modules
- forward group membership updates to the worker
- track members in the worker and persist to profiles
- include member arrays in relay update responses

## Testing
- `npm test` *(fails: `brittle` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859bc7a646c832a815920fbfeff2519