### PR TITLE
Fix worker member list persistence

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1245,7 +1245,14 @@ App.syncHypertunaConfigToFile = async function() {
      */
     App.loadGroupMembers = async function() {
         if (!this.currentUser || !this.currentGroupId) return;
-        
+
+        // Ensure member list is built from history
+        try {
+            await this.nostr.client.buildMemberList(this.currentGroupId);
+        } catch (err) {
+            console.error('Failed to build member list', err);
+        }
+
         const container = document.getElementById("member-list");
         if (!this.membersList) {
             this.membersList = new MembersList(container, this.nostr.client, this.currentUser.pubkey);

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -54,6 +54,10 @@ class NostrIntegration {
         await this.client.connectToGroupRelay(groupId, relayUrl);
     }
 
+    registerRelayMapping(relayKey, publicIdentifier) {
+        this.client.registerRelayMapping(relayKey, publicIdentifier);
+    }
+
     /**
      * Handle relay ready notification from worker
      */
@@ -134,10 +138,14 @@ class NostrIntegration {
             this._throttledGroupUpdate();
 
             if (window.workerPipe) {
-                const relayKey = this.client.publicToInternalMap?.get(groupId) || groupId;
+                const relayKey = this.client.publicToInternalMap?.get(groupId) || null;
                 const msg = {
                     type: 'update-members',
-                    data: { relayKey, members: members.map(m => m.pubkey) }
+                    data: {
+                        relayKey,
+                        publicIdentifier: groupId,
+                        members: members.map(m => m.pubkey)
+                    }
                 };
                 try {
                     window.workerPipe.write(JSON.stringify(msg) + '\n');

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -457,6 +457,10 @@ function handleWorkerMessage(message) {
       if (message.relayKey) {
         console.log(`[App] Relay initialized: ${message.relayKey}`)
         initializedRelays.add(message.relayKey)
+
+        if (window.App && window.App.nostr && message.publicIdentifier) {
+          window.App.nostr.registerRelayMapping(message.relayKey, message.publicIdentifier)
+        }
         
         // Resolve any waiting promises for this relay
         const resolver = relayReadyResolvers.get(message.relayKey)
@@ -531,6 +535,9 @@ function handleWorkerMessage(message) {
       if (resolver) resolver(message)
       if (message.data.success) {
         addLog(`Relay created successfully: ${message.data.relayKey}`, 'status')
+        if (window.App && window.App.nostr && message.data.publicIdentifier) {
+          window.App.nostr.registerRelayMapping(message.data.relayKey, message.data.publicIdentifier)
+        }
       } else {
         addLog(`Failed to create relay: ${message.data.error}`, 'error')
       }
@@ -539,6 +546,9 @@ function handleWorkerMessage(message) {
     case 'relay-joined':
       if (message.data.success) {
         addLog(`Joined relay successfully: ${message.data.relayKey}`, 'status')
+        if (window.App && window.App.nostr && message.data.publicIdentifier) {
+          window.App.nostr.registerRelayMapping(message.data.relayKey, message.data.publicIdentifier)
+        }
       } else {
         addLog(`Failed to join relay: ${message.data.error}`, 'error')
       }
@@ -713,6 +723,9 @@ function updateRelayList(relayData) {
   
   relayList.innerHTML = '';
   relays.forEach(relay => {
+    if (window.App && window.App.nostr && relay.relayKey && relay.publicIdentifier) {
+      window.App.nostr.registerRelayMapping(relay.relayKey, relay.publicIdentifier)
+    }
     const relayElement = document.createElement('div');
     relayElement.className = 'relay-item';
     

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -278,10 +278,18 @@ if (workerPipe) {
             case 'update-members':
               if (relayServer) {
                 try {
-                  const { relayKey, members } = message.data
-                  await updateRelayMembers(relayKey, members)
-                  relayMembers.set(relayKey, members)
-                  sendMessage({ type: 'members-updated', relayKey })
+                  const { relayKey, publicIdentifier, members } = message.data
+                  const id = relayKey || publicIdentifier
+                  const profile = await updateRelayMembers(id, members)
+                  if (profile) {
+                    relayMembers.set(profile.relay_key, members)
+                    if (profile.public_identifier) {
+                      relayMembers.set(profile.public_identifier, members)
+                    }
+                    sendMessage({ type: 'members-updated', relayKey: profile.relay_key })
+                  } else {
+                    sendMessage({ type: 'error', message: 'Relay profile not found' })
+                  }
                 } catch (err) {
                   sendMessage({ type: 'error', message: `Failed to update members: ${err.message}` })
                 }


### PR DESCRIPTION
## Summary
- allow member sync to specify public identifier when notifying worker
- expose registerRelayMapping on integration and client
- update UI to store mapping when relays are listed or created
- handle update-members in worker using either relay key or identifier
- support lookup of profiles by public identifier when updating members

## Testing
- `npm test` (failed: brittle not found)
- `npm test` (failed: brittle not found)


------
https://chatgpt.com/codex/tasks/task_e_685a15384a58832a95f20723e62ba31d