### PR TITLE
Update worker to honor relay security flags

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -58,7 +58,7 @@ async function ensureProfilesInitialized(userKey = null) {
  * @returns {Promise<Object>} - Result object with relay information
  */
 export async function createRelay(options = {}) {
-    const { name, description, storageDir, config } = options;
+    const { name, description, isPublic = false, isOpen = false, storageDir, config } = options;
     
     // Store config and user key globally if provided
     if (config) {
@@ -106,7 +106,18 @@ export async function createRelay(options = {}) {
             relay_storage: defaultStorageDir,
             created_at: new Date().toISOString(),
             auto_connect: true,
-            is_active: true
+            is_active: true,
+            isPublic,
+            isOpen,
+            auth_config: {
+                requiresAuth: true,
+                tokenProtected: true,
+                isPublic,
+                isOpen,
+                authorizedUsers: [],
+                auth_adds: [],
+                auth_removes: []
+            }
         };
         
         // Save relay profile

--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -63,7 +63,15 @@ function ensureProfileSchema(profile) {
     if (!Array.isArray(profile.auth_removes)) {
         profile.auth_removes = [];
     }
-    
+
+    // NEW: ensure visibility and join flags exist
+    if (profile.isPublic === undefined) {
+        profile.isPublic = false;
+    }
+    if (profile.isOpen === undefined) {
+        profile.isOpen = false;
+    }
+
     return profile;
 }
 


### PR DESCRIPTION
## Summary
- persist `isPublic` and `isOpen` flags in relay profiles
- default worker profiles to include authentication metadata
- expose the flags in relay creation workflow

## Testing
- `npm test --silent` *(fails: `brittle` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f27935cf0832a9a82c448df5c2b10