### PR TITLE
Fix create relay workflow

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1450,16 +1450,22 @@ App.syncHypertunaConfigToFile = async function() {
 
             const proxyServer = this.currentUser?.hypertunaConfig?.proxy_server_address || '';
 
-            const eventsCollection = await this.nostr.createGroup(
-                name, about, isPublic, isOpen, relayKey, proxyServer, npub
-            );
-            
-            // The worker now returns the auth token in the relayKey object
             if (relayKey && relayKey.authToken) {
-                this.showAuthSuccess(relayKey);
+                await this.showAuthSuccess(relayKey);
             } else {
                 this.closeJoinAuthModal();
             }
+
+            const eventsCollection = await this.nostr.createGroup(
+                name,
+                about,
+                isPublic,
+                isOpen,
+                relayKey,
+                proxyServer,
+                npub,
+                relayKey?.relayUrl || null
+            );
 
             console.log(`Group created successfully with public ID: ${eventsCollection.groupId}`);
             console.log(`Internal relay key: ${eventsCollection.internalRelayKey}`);

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -408,9 +408,10 @@ class NostrIntegration {
      * @param {string} about - Group description
      * @param {boolean} isPublic - Whether the group is public
      * @param {boolean} isOpen - Whether the group is open to join
+     * @param {string} [authenticatedRelayUrl] - Tokenized relay URL from the worker
      * @returns {Promise<Object>} - Create group events collection
      */
-    async createGroup(name, about, isPublic, isOpen, relayKey, proxyServer, npub) {
+    async createGroup(name, about, isPublic, isOpen, relayKey, proxyServer, npub, authenticatedRelayUrl = null) {
         try {
             // Validate inputs
             if (typeof name !== 'string') {
@@ -426,7 +427,7 @@ class NostrIntegration {
                 throw new Error('isOpen must be a boolean');
             }
             
-            console.log("NostrIntegration creating group:", { name, about, isPublic, isOpen, npub });
+            console.log("NostrIntegration creating group:", { name, about, isPublic, isOpen, npub, authenticatedRelayUrl });
         
             const eventsCollection = await this.client.createGroup({
                 name,
@@ -435,7 +436,8 @@ class NostrIntegration {
                 isOpen,
                 relayKey,
                 proxyServer,
-                npub
+                npub,
+                authenticatedRelayUrl
             });
             
             console.log('Group created successfully with the following events:');


### PR DESCRIPTION
## Summary
- ensure the tokenized relay URL is used when creating a group
- pass the authenticated relay URL through the integration layer
- connect and publish to the relay only after token issuance

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c6d515b0832aabfa705d0c086558