### PR TITLE
Fix relay profile sync

### DIFF
--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -19,6 +19,7 @@ import {
   updateRelayMemberSets,
   calculateMembers
 } from './hypertuna-relay-profile-manager-bare.mjs'
+import { loadRelayKeyMappings } from './hypertuna-relay-manager-adapter.mjs'
 
 // In Pear, use the config.dir for the application directory
 const __dirname = Pear.config.dir || '.'
@@ -548,6 +549,7 @@ async function main() {
         console.log('[Worker] Set global user config for profile operations');
 
         await loadRelayMembers();
+        await loadRelayKeyMappings();
       }
     }
     


### PR DESCRIPTION
## Summary
- manage map of public identifiers to relay keys
- sync auth store when profiles change
- keep mapping updated when profiles are saved or removed
- load mapping during worker startup

## Testing
- `npm test --silent` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620635cdb8832a84f5cbc54f865ca2