### PR TITLE
Fix relay auth url preservation

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -286,7 +286,7 @@ class NostrGroupClient {
 
                         // Check if we have an updated URL from the worker
                         const updatedUrl = this.groupRelayUrls.get(identifier);
-                        if (updatedUrl && updatedUrl !== connection.relayUrl) {
+                        if (updatedUrl && updatedUrl !== connection.relayUrl && updatedUrl.includes('token=')) {
                             console.log(`[NostrGroupClient] Using updated authenticated URL for ${identifier}`);
                             connection.relayUrl = updatedUrl;
                         }
@@ -349,11 +349,13 @@ class NostrGroupClient {
         
         // Check if this relay is in our pending connections
         const pending = this.pendingRelayConnections.get(identifier);
-        if (pending && pending.status === 'pending') {
+        if (pending && pending.status !== 'connected') {
             console.log(`[NostrGroupClient] Found pending connection for ${identifier}, updating with authenticated URL`);
             // Update the pending connection with the authenticated URL
             pending.relayUrl = gatewayUrl;
-            this.processRelayConnectionQueue();
+            if (pending.status === 'pending') {
+                this.processRelayConnectionQueue();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure we only override connection URLs when they contain an auth token
- update pending connections with tokenized URL even if already connecting

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_686333515f28832aacdc8a8b590bd798