### PR TITLE
Fix auth update with subnet hashes

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1632,7 +1632,7 @@ async fetchMultipleProfiles(pubkeys) {
         event.tags.forEach(tag => {
             if (tag[0] === 'p' && tag[1]) {
                 const pubkey = tag[1];
-                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token, subnetHash]
+                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token, subnetHash1, subnetHash2]
                 const actualRoles = [rolesAndAuthData[0]]; // 'member' or 'admin'
                 const token = rolesAndAuthData[1]; // The auth token
                 const subnetHashes = rolesAndAuthData.slice(2); // All subsequent elements are subnet hashes
@@ -1640,8 +1640,8 @@ async fetchMultipleProfiles(pubkeys) {
                 addMap.set(pubkey, { ts: event.created_at, roles: actualRoles });
                 this.relevantPubkeys.add(pubkey);
 
-                // If token and subnetHash are present, send to worker for auth data update
-                if (token && subnetHash && window.workerPipe) {
+                // If token and at least one subnet hash are present, send to worker for auth data update
+                if (token && subnetHashes.length > 0 && window.workerPipe) {
                     const relayKey = this.publicToInternalMap.get(groupId) || null;
                     const msg = {
                         type: 'update-auth-data',

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -407,12 +407,13 @@ if (workerPipe) {
               console.log('[Worker] Update auth data requested:', message.data);
               if (relayServer) {
                 try {
-                  const { relayKey, publicIdentifier, pubkey, token, subnetHash } = message.data;
+                  const { relayKey, publicIdentifier, pubkey, token, subnetHashes } = message.data;
                   const identifier = relayKey || publicIdentifier;
                   if (!identifier) {
                     throw new Error('No identifier provided for auth data update');
                   }
-                  await updateRelayAuthToken(identifier, pubkey, token, subnetHash);
+                  const subnets = Array.isArray(subnetHashes) ? subnetHashes : [];
+                  await updateRelayAuthToken(identifier, pubkey, token, subnets);
                   sendMessage({
                     type: 'auth-data-updated',
                     identifier: identifier,


### PR DESCRIPTION
## Summary
- check subnet arrays correctly before sending auth updates
- handle subnet hash arrays in worker when updating auth data

## Testing
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*
- `npm test --prefix hypertuna-desktop` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633fa0f244832ab27ade04475af76d