### PR TITLE
Remove subnet hash from gateway

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1632,16 +1632,15 @@ async fetchMultipleProfiles(pubkeys) {
         event.tags.forEach(tag => {
             if (tag[0] === 'p' && tag[1]) {
                 const pubkey = tag[1];
-                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token, subnetHash]
+                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token]
                 const actualRoles = [rolesAndAuthData[0]]; // 'member' or 'admin'
                 const token = rolesAndAuthData[1]; // The auth token
-                const subnetHashes = rolesAndAuthData.slice(2); // All subsequent elements are subnet hashes
 
                 addMap.set(pubkey, { ts: event.created_at, roles: actualRoles });
                 this.relevantPubkeys.add(pubkey);
 
-                // If token and subnetHash are present, send to worker for auth data update
-                if (token && subnetHash && window.workerPipe) {
+                // If token is present, send to worker for auth data update
+                if (token && window.workerPipe) {
                     const relayKey = this.publicToInternalMap.get(groupId) || null;
                     const msg = {
                         type: 'update-auth-data',
@@ -1649,8 +1648,7 @@ async fetchMultipleProfiles(pubkeys) {
                             relayKey,
                             publicIdentifier: groupId,
                             pubkey,
-                            token,
-                            subnetHashes 
+                            token
                         }
                     };
                     try {

--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -444,7 +444,7 @@ class EnhancedHyperswarmPool {
   }
  }
  
- async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, subnetHash, authToken) {
+async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, authToken) {
   try {
     console.log(`[ForwardMessage] ========================================`);
     console.log(`[ForwardMessage] FORWARDING RELAY MESSAGE`);
@@ -452,7 +452,6 @@ class EnhancedHyperswarmPool {
     console.log(`[ForwardMessage] Connection: ${connectionKey}`);
     console.log(`[ForwardMessage] Peer: ${peerPublicKey.substring(0, 8)}...`);
     console.log(`[ForwardMessage] Has auth: ${!!authToken}`);
-    console.log(`[ForwardMessage] Subnet: ${subnetHash?.substring(0, 8)}...`);
     
     const connection = await connectionPool.getConnection(peerPublicKey);
     
@@ -460,9 +459,6 @@ class EnhancedHyperswarmPool {
     const headers = { 'content-type': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
     
     const response = await connection.sendRequest({
@@ -501,7 +497,6 @@ class EnhancedHyperswarmPool {
     console.log(`[ForwardJoin] Relay: ${identifier}`);
     console.log(`[ForwardJoin] Peer: ${peer.publicKey.substring(0, 8)}...`);
     console.log(`[ForwardJoin] Has event: ${!!requestData.event}`);
-    console.log(`[ForwardJoin] Subnet hash: ${requestData.requesterSubnetHash?.substring(0, 8)}...`);
     
     const connection = await connectionPool.getConnection(peer.publicKey);
     
@@ -570,7 +565,7 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
   }
 }
  
- async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null, subnetHash = null) {
+async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null) {
   try {
     console.log(`[GetEvents] Checking for events - relay: ${relayKey}, connection: ${connectionKey}`);
     
@@ -579,9 +574,6 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
     const headers = { 'accept': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
 
     const response = await connection.sendRequest({

--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -142,7 +142,6 @@ export async function createRelay(options = {}) {
             auth_adds.push({
                 pubkey: config.nostr_pubkey_hex,
                 token: authToken,
-                subnets: [], // Will be populated on first connection
                 ts: Date.now()
             });
             
@@ -543,7 +542,6 @@ export async function autoConnectStoredRelays(config) {
                         authorizedUsers.forEach(user => {
                             authData[user.pubkey] = {
                                 token: user.token,
-                                allowedSubnets: user.subnets || [],
                                 createdAt: Date.now(),
                                 lastUsed: Date.now()
                             };
@@ -624,7 +622,6 @@ export async function autoConnectStoredRelays(config) {
                     authorizedUsers.forEach(user => {
                         authData[user.pubkey] = {
                             token: user.token,
-                            allowedSubnets: user.subnets || [],
                             createdAt: Date.now(),
                             lastUsed: Date.now()
                         };

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -407,12 +407,12 @@ if (workerPipe) {
               console.log('[Worker] Update auth data requested:', message.data);
               if (relayServer) {
                 try {
-                  const { relayKey, publicIdentifier, pubkey, token, subnetHash } = message.data;
+                  const { relayKey, publicIdentifier, pubkey, token } = message.data;
                   const identifier = relayKey || publicIdentifier;
                   if (!identifier) {
                     throw new Error('No identifier provided for auth data update');
                   }
-                  await updateRelayAuthToken(identifier, pubkey, token, subnetHash);
+                  await updateRelayAuthToken(identifier, pubkey, token);
                   sendMessage({
                     type: 'auth-data-updated',
                     identifier: identifier,

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -12,7 +12,7 @@ async function setupLegacyProfile() {
   const profile = {
     relay_key: 'relay1',
     name: 'Legacy',
-    auth_adds: [{ pubkey: 'pub1', token: 'old', subnets: [], ts: 1 }],
+    auth_adds: [{ pubkey: 'pub1', token: 'old', ts: 1 }],
     auth_removes: [],
     auth_config: { requiresAuth: true, tokenProtected: true }
   }
@@ -23,10 +23,10 @@ async function setupLegacyProfile() {
 
 test('updateRelayAuthToken migrates legacy auth fields', async t => {
   const tmp = await setupLegacyProfile()
-  await updateRelayAuthToken('relay1', 'pub1', 'new', ['sub1'])
+  await updateRelayAuthToken('relay1', 'pub1', 'new')
   const profiles = await getAllRelayProfiles()
   t.is(profiles[0].auth_adds, undefined)
   t.is(profiles[0].auth_removes, undefined)
-  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', subnets: ['sub1'], ts: profiles[0].auth_config.auth_adds[0].ts }])
+  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', ts: profiles[0].auth_config.auth_adds[0].ts }])
   await fs.rm(tmp, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary
- drop subnet logic from gateway server
- update gateway->worker client utilities for token-only auth
- simplify relay server messages accordingly
- fix profile manager adapter comment
- adjust test expectations for token-only auth

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68635f3d683c832a86011a4e594c33e1