### PR TITLE
Ensure relays fully ready before Nostr connections

### DIFF
--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -1637,6 +1637,18 @@ async function registerWithGateway(relayProfileInfo = null) {
               type: 'gateway-registered',
               data: response
           });
+
+          if (relayProfileInfo) {
+              const identifier = relayProfileInfo.public_identifier || relayProfileInfo.relay_key;
+              const gwUrl = `wss://${config.proxy_server_address}/${identifier.replace(':', '/')}`;
+              global.sendMessage({
+                  type: 'relay-registration-complete',
+                  relayKey: relayProfileInfo.relay_key,
+                  publicIdentifier: relayProfileInfo.public_identifier,
+                  gatewayUrl: gwUrl,
+                  timestamp: new Date().toISOString()
+              });
+          }
       }
   } catch (error) {
       console.error('[RelayServer] Gateway HTTP registration FAILED:', error.message);


### PR DESCRIPTION
## Summary
- track initialized and registered relays in the desktop app
- resolve waiting promises only after both initialization and registration
- notify Nostr layer once per relay when ready
- clear relay state on worker restarts and shutdowns
- remove duplicate `relay-initialized` handler
- emit `relay-registration-complete` whenever HTTP registration succeeds

## Testing
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*
- `npm test` in `hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a4dba1a4832ab592f4e0f51161c7