### PR TITLE
Fix relay readiness message handling

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -2697,6 +2697,16 @@ App.setupFollowingModalListeners = function() {
             this.nostr.handleRelayRegistered(identifier);
         }
     };
+
+    // Process any queued worker messages that arrived before handlers were ready
+    if (window.pendingRelayMessages) {
+        while (window.pendingRelayMessages.initialized.length) {
+            App.handleRelayInitialized(window.pendingRelayMessages.initialized.shift());
+        }
+        while (window.pendingRelayMessages.registered.length) {
+            App.handleRelayRegistered(window.pendingRelayMessages.registered.shift());
+        }
+    }
     
     /**
      * Replace update profile method

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -417,43 +417,6 @@ class NostrGroupClient {
         });
     }
 
-    /**
-     * Checks if a relay is both initialized and registered, then connects.
-     * This is called by both handleRelayInitialized and handleRelayRegistered
-     * to make the process resilient to message ordering.
-     * @private
-     */
-    async _attemptConnectionIfReady(identifier) {
-        const connection = this.pendingRelayConnections.get(identifier);
-    
-        if (!connection) {
-            console.log(`[NostrGroupClient] No pending connection for ${identifier} yet.`);
-            return;
-        }
-    
-        // Only proceed if we have a valid authenticated URL
-        if (connection.isInitialized && connection.isRegistered && 
-            connection.status === 'pending' && connection.relayUrl && 
-            connection.relayUrl.includes('?token=')) {
-            
-            console.log(`[NostrGroupClient] All checks passed for ${identifier}. Connecting to ${connection.relayUrl}`);
-            connection.status = 'connecting';
-            
-            try {
-                await this.connectToGroupRelay(identifier, connection.relayUrl);
-                connection.status = 'connected';
-                this.pendingRelayConnections.delete(identifier);
-            } catch (e) {
-                console.error(`[NostrGroupClient] Final connection attempt failed for ${identifier}:`, e);
-                connection.status = 'failed';
-            }
-        } else {
-            console.log(`[NostrGroupClient] Waiting on readiness for ${identifier}. ` +
-                `Initialized=${connection.isInitialized}, ` +
-                `Registered=${connection.isRegistered}, ` +
-                `Has valid URL=${connection.relayUrl && connection.relayUrl.includes('?token=')}`);
-        }
-    }
 
     /**
      * Handle all relays ready notification


### PR DESCRIPTION
## Summary
- queue early worker messages until relay handlers are ready
- remove duplicate `_attemptConnectionIfReady` implementation
- flush queued messages once `AppIntegration` sets up relay handlers

## Testing
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*
- `npm test` in `hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c6fba23c832abd1c860f83855892