### PR TITLE
Relax subnet verification in worker

### DIFF
--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -1251,8 +1251,8 @@ protocol.handle('/authorize', async (request) => {
           // Some relays might allow public read access
           // You can customize this based on your requirements
           if (profile?.auth_config?.publicRead !== true) {
-            if (!authToken || !subnetHash) {
-              console.warn(`[RelayServer] Missing auth for REQ on protected relay`);
+            if (!authToken) {
+              console.warn(`[RelayServer] Missing auth token for REQ on protected relay`);
               updateMetrics(false);
               return {
                 statusCode: 403,
@@ -1262,7 +1262,7 @@ protocol.handle('/authorize', async (request) => {
                 ]))
               };
             }
-            
+
             // Verify auth for REQ
             const auth = authStore.verifyAuth(relayKey, authToken, subnetHash);
             if (!auth) {
@@ -1285,10 +1285,10 @@ protocol.handle('/authorize', async (request) => {
         if (nostrMessage[0] === 'EVENT') {
           const event = nostrMessage.length === 2 ? nostrMessage[1] : nostrMessage[2];
           
-          if (!authToken || !subnetHash) {
-            console.warn(`[RelayServer] Missing auth token or subnet hash for EVENT`);
+          if (!authToken) {
+            console.warn(`[RelayServer] Missing auth token for EVENT`);
             updateMetrics(false);
-            
+
             // Return proper NOSTR OK response with auth error
             const okResponse = ['OK', event?.id || '', false, 'error: authentication required'];
             return {
@@ -1301,7 +1301,7 @@ protocol.handle('/authorize', async (request) => {
           // Verify the auth
           const auth = authStore.verifyAuth(relayKey, authToken, subnetHash);
           if (!auth) {
-            console.warn(`[RelayServer] Invalid auth token or subnet`);
+            console.warn(`[RelayServer] Invalid auth token`);
             updateMetrics(false);
             
             const okResponse = ['OK', event?.id || '', false, 'error: invalid authentication'];
@@ -1454,8 +1454,8 @@ protocol.handle('/authorize', async (request) => {
           // This endpoint is implicitly for REQ messages (fetching events for a subscription)
           // Check if public read access is explicitly allowed
           if (profile?.auth_config?.publicRead !== true) {
-            if (!authToken || !subnetHash) {
-              console.warn(`[RelayServer] Missing auth for read access on protected relay`);
+            if (!authToken) {
+              console.warn(`[RelayServer] Missing auth token for read access on protected relay`);
               updateMetrics(false);
               return {
                 statusCode: 200, // Return 200 for valid NOSTR NOTICE response

--- a/hypertuna-worker/relay-auth-store.mjs
+++ b/hypertuna-worker/relay-auth-store.mjs
@@ -78,19 +78,19 @@ getAuthByToken(relayKey, token) {
   }
   
   /**
-   * Verify token and subnet
+   * Verify token only (subnet is ignored)
    * @param {string} relayKey - Relay identifier
    * @param {string} token - Auth token
-   * @param {string} subnetHash - Client subnet hash
+   * @param {string} [subnetHash] - Client subnet hash (ignored)
    * @returns {Object|null} - User auth data or null
    */
   verifyAuth(relayKey, token, subnetHash) {
     const relayAuth = this.relayAuths.get(relayKey);
     if (!relayAuth) return null;
-    
+
     // Find user by token
     for (const [pubkey, auth] of relayAuth) {
-      if (auth.token === token && auth.allowedSubnets.includes(subnetHash)) {
+      if (auth.token === token) {
         auth.lastUsed = Date.now();
         return { pubkey, ...auth };
       }

--- a/relay-auth-demo/demo-nostr-relay-auth.js
+++ b/relay-auth-demo/demo-nostr-relay-auth.js
@@ -45,10 +45,10 @@ function extractTokenFromReq(req) {
 
 function isAuthorized(token, ip) {
   const subnet = get24Subnet(ip);
-  const ipHash = sha256(subnet);
+  const ipHash = sha256(subnet); // retained for logging or future use
   for (const pubkey in allowlist) {
     const entry = allowlist[pubkey];
-    if (entry.token === token && entry.allowedSubnets.includes(ipHash)) {
+    if (entry.token === token) {
       return pubkey;
     }
   }


### PR DESCRIPTION
## Summary
- relax subnet matching in `RelayAuthStore.verifyAuth`
- update NOSTR worker to only require auth token
- adjust demo auth logic accordingly

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753f4aca6c832aa4eb955fdc476bd2