### PR TITLE
Fix public relay list update logic

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1458,7 +1458,7 @@ App.syncHypertunaConfigToFile = async function() {
             const proxyServer = this.currentUser?.hypertunaConfig?.proxy_server_address || '';
 
             if (relayKey && relayKey.authToken) {
-                await this.showAuthSuccess(relayKey);
+                await this.showAuthSuccess(relayKey, isPublic);
             } else {
                 this.closeJoinAuthModal();
             }
@@ -1612,8 +1612,10 @@ App.syncHypertunaConfigToFile = async function() {
 
     /**
      * Show authentication success
+     * @param {Object} authResult - Result object from the worker
+     * @param {boolean|null} [isPublic] - Public flag for the relay if known
      */
-    App.showAuthSuccess = async function(authResult) {
+    App.showAuthSuccess = async function(authResult, isPublic = null) {
         // Update progress to complete
         this.updateAuthProgress('complete');
         
@@ -1653,7 +1655,8 @@ App.syncHypertunaConfigToFile = async function() {
             await this.nostr.client.updateUserRelayListWithAuth(
                 authResult.publicIdentifier,
                 authResult.relayUrl, // This should be the full authenticated URL
-                authResult.authToken
+                authResult.authToken,
+                isPublic
             );
         } else {
             console.error("Nostr client not available to update relay list.");

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2417,13 +2417,17 @@ async fetchMultipleProfiles(pubkeys) {
 
     /**
      * Update user relay list with authentication token
+     * @param {string} publicIdentifier - Relay public identifier
+     * @param {string} authenticatedUrl - Full relay URL including auth token
+     * @param {string} authToken - Authentication token
+     * @param {boolean|null} [isPublicOverride] - Optional override for relay publicity
      * @private
      */
-    async updateUserRelayListWithAuth(publicIdentifier, authenticatedUrl, authToken) {
+    async updateUserRelayListWithAuth(publicIdentifier, authenticatedUrl, authToken, isPublicOverride = null) {
         // Get group metadata
         const group = this.groups.get(publicIdentifier);
         const groupName = group?.name || '';
-        const isPublic = group?.isPublic || false;
+        const isPublic = isPublicOverride !== null ? isPublicOverride : (group?.isPublic || false);
         
         // The authenticatedUrl is passed in directly from the worker's response,
         // which already includes the token.


### PR DESCRIPTION
## Summary
- ensure public relay tokenized URLs are stored in unencrypted tags
- allow caller to pass isPublic flag when updating relay list after auth

## Testing
- `npm test` *(fails: brittle not found)*


------
https://chatgpt.com/codex/tasks/task_e_6877028bf4ac832aaf2ea772a8e8d341