### PR TITLE
Use b4a for bare text/byte conversions

### DIFF
--- a/hypertuna-worker/challenge-manager.mjs
+++ b/hypertuna-worker/challenge-manager.mjs
@@ -1,6 +1,7 @@
 // challenge-manager.mjs - Challenge generation and verification for relay authentication
 
 import crypto from 'bare-crypto';
+import b4a from 'b4a';
 import { nobleSecp256k1 } from './pure-secp256k1-bare.js';
 
 /**
@@ -120,7 +121,7 @@ export class ChallengeManager {
   getPublicKeyFromPrivate(privateKeyHex) {
     const pubKeyBytes = nobleSecp256k1.getPublicKey(privateKeyHex, true);
     // Remove the compression prefix (first byte) for x-only pubkey
-    return Buffer.from(pubKeyBytes.slice(1)).toString('hex');
+    return b4a.toString(pubKeyBytes.slice(1), 'hex');
   }
   
   /**
@@ -177,7 +178,7 @@ export class ChallengeManager {
       );
       
       // Use the same key derivation as the demo - slice from index 1 to 33
-      const keyBuffer = Buffer.from(sharedSecret.slice(1, 33));
+      const keyBuffer = b4a.from(sharedSecret.slice(1, 33));
       
       console.log(`[ChallengeManager] Shared key: ${keyBuffer.toString('hex').substring(0, 16)}...`);
       
@@ -223,14 +224,14 @@ export class ChallengeManager {
    * @returns {string} - Decrypted text
    */
   aesDecrypt(keyBuffer, ciphertext, ivBase64) {
-    const iv = Buffer.from(ivBase64, 'base64');
-    const ciphertextBuffer = Buffer.from(ciphertext, 'base64');
+    const iv = b4a.from(ivBase64, 'base64');
+    const ciphertextBuffer = b4a.from(ciphertext, 'base64');
     
     // Use the AES implementation from pure-secp256k1-bare.js
     const decrypted = nobleSecp256k1.aes.decrypt(ciphertextBuffer, keyBuffer, iv);
     
     // Convert to string
-    return Buffer.from(decrypted).toString('utf8');
+    return b4a.toString(decrypted, 'utf8');
   }
   
   /**

--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -25,8 +25,7 @@ function serializeEvent(event) {
 async function getEventHash(event) {
   logWithTimestamp("getEventHash: Generating hash for event", event);
   const serialized = JSON.stringify([0, event.pubkey, event.created_at, event.kind, event.tags, event.content]);
-  // Use Buffer instead of TextEncoder for Bare compatibility
-  const hashBytes = await nobleSecp256k1.utils.sha256(Buffer.from(serialized, 'utf8'));
+  const hashBytes = await nobleSecp256k1.utils.sha256(b4a.from(serialized, 'utf8'));
   const hash = NostrUtils.bytesToHex(hashBytes);
   logWithTimestamp("getEventHash: Generated hash", hash);
   return hash;
@@ -102,8 +101,7 @@ async function verifyEventSignature(event) {
   
   try {
     const serializedEvent = serializeEvent(event);
-    // Use Buffer instead of TextEncoder for Bare compatibility
-    const eventHashBytes = await nobleSecp256k1.utils.sha256(Buffer.from(serializedEvent, 'utf8'));
+    const eventHashBytes = await nobleSecp256k1.utils.sha256(b4a.from(serializedEvent, 'utf8'));
     const eventHashHex = NostrUtils.bytesToHex(eventHashBytes);
     
     logWithTimestamp('verifyEventSignature: Serialized event:', serializedEvent);

--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -45,8 +45,7 @@ async function verifyEventSignature(event) {
       console.log('Serialized Event:', serialized);
       
       // Use sha256 which returns Uint8Array
-      // In Bare, use Buffer instead of TextEncoder
-      const hashBytes = await nobleSecp256k1.utils.sha256(Buffer.from(serialized, 'utf8'));
+      const hashBytes = await nobleSecp256k1.utils.sha256(b4a.from(serialized, 'utf8'));
       const hashHex = NostrUtils.bytesToHex(hashBytes);
       console.log('Event Hash:', hashHex);
       
@@ -76,8 +75,7 @@ function serializeEvent(event) {
 
 async function getEventHash(event) {
   const serialized = JSON.stringify([0, event.pubkey, event.created_at, event.kind, event.tags, event.content]);
-  // In Bare, use Buffer instead of TextEncoder
-  const hashBytes = await nobleSecp256k1.utils.sha256(Buffer.from(serialized, 'utf8'));
+  const hashBytes = await nobleSecp256k1.utils.sha256(b4a.from(serialized, 'utf8'));
   return NostrUtils.bytesToHex(hashBytes);
 }
 
@@ -306,8 +304,7 @@ export class RelayManager {
       };
       
       const serializedEvent = serializeEvent(event);
-      // In Bare, use Buffer instead of TextEncoder
-      const eventHashBytes = await nobleSecp256k1.utils.sha256(Buffer.from(serializedEvent, 'utf8'));
+      const eventHashBytes = await nobleSecp256k1.utils.sha256(b4a.from(serializedEvent, 'utf8'));
       event.id = NostrUtils.bytesToHex(eventHashBytes);
       
       // Sign the event - schnorr.sign returns Uint8Array

--- a/hypertuna-worker/nostr-utils.js
+++ b/hypertuna-worker/nostr-utils.js
@@ -6,6 +6,7 @@
 
 // Import from local module if available, otherwise try window object
 import { nobleSecp256k1 } from './crypto-libraries.js';
+import b4a from 'b4a';
 
 export class NostrUtils {
     /**
@@ -91,7 +92,7 @@ export class NostrUtils {
         
         // Generate the event ID (sha256 returns Uint8Array)
         const hashBytes = await secp.utils.sha256(
-            Buffer.from(eventData, 'utf8')
+            b4a.from(eventData, 'utf8')
         );
         event.id = this.bytesToHex(hashBytes);
         
@@ -126,7 +127,7 @@ export class NostrUtils {
             ]);
             
             const hashBytes = await secp.utils.sha256(
-                Buffer.from(eventData, 'utf8')
+                b4a.from(eventData, 'utf8')
             );
             const id = this.bytesToHex(hashBytes);
             

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -6,6 +6,7 @@ import { join } from 'bare-path';
 import crypto from 'hypercore-crypto';
 import { setTimeout, setInterval, clearInterval } from 'bare-timers';
 import https from 'bare-https';
+import b4a from 'b4a';
 import { URL } from 'bare-url';
 import { initializeChallengeManager, getChallengeManager } from './challenge-manager.mjs';
 import { getRelayAuthStore } from './relay-auth-store.mjs';
@@ -231,7 +232,7 @@ async function startHyperswarmServer() {
     console.log('[RelayServer] Starting Hyperswarm server...');
     
     // Create key pair from seed
-    const keyPair = crypto.keyPair(Buffer.from(config.proxy_seed, 'hex'));
+    const keyPair = crypto.keyPair(b4a.from(config.proxy_seed, 'hex'));
     config.swarmPublicKey = keyPair.publicKey.toString('hex');
     // Persist the generated public key so it can be read on next start
     await saveConfig(config);
@@ -267,7 +268,7 @@ async function startHyperswarmServer() {
     
     // Join the swarm with a well-known topic
     const topicString = 'hypertuna-relay-network';
-    const topic = crypto.hash(Buffer.from(topicString));
+    const topic = crypto.hash(b4a.from(topicString));
     console.log('[RelayServer] Joining swarm with topic:', topicString);
     console.log('[RelayServer] Topic hash:', topic.toString('hex'));
     
@@ -392,7 +393,7 @@ function handlePeerConnection(stream, peerInfo) {
         id: request.id,
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ 
+        body: b4a.from(JSON.stringify({ 
           status: 'identified',
           relayPublicKey: config.swarmPublicKey,
           timestamp: new Date().toISOString()
@@ -533,7 +534,7 @@ function setupProtocolHandlers(protocol) {
     return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify(healthResponse))
+        body: b4a.from(JSON.stringify(healthResponse))
     };
 });
   
@@ -568,7 +569,7 @@ function setupProtocolHandlers(protocol) {
         return {
             statusCode: 200,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify({
+            body: b4a.from(JSON.stringify({
                 relays: relayList,
                 count: relayList.length
             }))
@@ -579,7 +580,7 @@ function setupProtocolHandlers(protocol) {
         return {
             statusCode: 500,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify({ error: error.message }))
+            body: b4a.from(JSON.stringify({ error: error.message }))
         };
     }
 });
@@ -597,7 +598,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 400,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: 'Relay name is required' }))
+        body: b4a.from(JSON.stringify({ error: 'Relay name is required' }))
       };
     }
     
@@ -645,7 +646,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 200,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify(result))
+          body: b4a.from(JSON.stringify(result))
         };
       } else {
         console.error('[RelayServer] Failed to create relay:', result.error);
@@ -653,7 +654,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 500,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: result.error }))
+          body: b4a.from(JSON.stringify({ error: result.error }))
         };
       }
     } catch (error) {
@@ -662,7 +663,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: error.message }))
+        body: b4a.from(JSON.stringify({ error: error.message }))
       };
     }
   });
@@ -680,7 +681,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 400,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: 'Relay key is required' }))
+        body: b4a.from(JSON.stringify({ error: 'Relay key is required' }))
       };
     }
     
@@ -728,7 +729,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 200,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify(result))
+          body: b4a.from(JSON.stringify(result))
         };
       } else {
         console.error('[RelayServer] Failed to join relay:', result.error);
@@ -736,7 +737,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 500,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: result.error }))
+          body: b4a.from(JSON.stringify({ error: result.error }))
         };
       }
     } catch (error) {
@@ -745,7 +746,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: error.message }))
+        body: b4a.from(JSON.stringify({ error: error.message }))
       };
     }
   });
@@ -764,7 +765,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 400,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: 'Missing required fields' }))
+          body: b4a.from(JSON.stringify({ error: 'Missing required fields' }))
         };
       }
       
@@ -774,7 +775,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 400,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: 'Invalid event kind' }))
+          body: b4a.from(JSON.stringify({ error: 'Invalid event kind' }))
         };
       }
       
@@ -804,7 +805,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify(response))
+        body: b4a.from(JSON.stringify(response))
       };
       
     } catch (error) {
@@ -813,7 +814,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: error.message }))
+        body: b4a.from(JSON.stringify({ error: error.message }))
       };
     }
   });
@@ -833,7 +834,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 400,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: 'Missing required fields' }))
+          body: b4a.from(JSON.stringify({ error: 'Missing required fields' }))
         };
       }
       
@@ -851,7 +852,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 400,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: result.error }))
+          body: b4a.from(JSON.stringify({ error: result.error }))
         };
       }
       
@@ -864,7 +865,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({
+        body: b4a.from(JSON.stringify({
           success: true,
           token: result.token,
           identifier: result.identifier
@@ -882,7 +883,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: error.message }))
+        body: b4a.from(JSON.stringify({ error: error.message }))
       };
     }
   });
@@ -915,7 +916,7 @@ function setupProtocolHandlers(protocol) {
         return {
           statusCode: 400,
           headers: { 'content-type': 'application/json' },
-          body: Buffer.from(JSON.stringify({ error: 'Missing required fields for finalization' }))
+          body: b4a.from(JSON.stringify({ error: 'Missing required fields for finalization' }))
         };
       }
       
@@ -977,7 +978,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({
+        body: b4a.from(JSON.stringify({
           success: true,
           relayKey: identifier,
           authToken: token,
@@ -996,7 +997,7 @@ function setupProtocolHandlers(protocol) {
       return {
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: error.message }))
+        body: b4a.from(JSON.stringify({ error: error.message }))
       };
     }
   });
@@ -1017,7 +1018,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 400,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: 'Missing token' }))
+        body: b4a.from(JSON.stringify({ error: 'Missing token' }))
       };
     }
     
@@ -1057,7 +1058,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 403,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: 'Invalid token' }))
+        body: b4a.from(JSON.stringify({ error: 'Invalid token' }))
       };
     }
     
@@ -1080,7 +1081,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({
+        body: b4a.from(JSON.stringify({
           success: true,
           message: 'Mobile device authorized'
         }))
@@ -1090,7 +1091,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 400,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: 'Failed to add subnet' }))
+        body: b4a.from(JSON.stringify({ error: 'Failed to add subnet' }))
       };
     }
     
@@ -1104,7 +1105,7 @@ protocol.handle('/authorize', async (request) => {
     return {
       statusCode: 500,
       headers: { 'content-type': 'application/json' },
-      body: Buffer.from(JSON.stringify({ error: error.message }))
+      body: b4a.from(JSON.stringify({ error: error.message }))
     };
   }
 });
@@ -1125,7 +1126,7 @@ protocol.handle('/authorize', async (request) => {
                 return {
                     statusCode: 404,
                     headers: { 'content-type': 'application/json' },
-                    body: Buffer.from(JSON.stringify({ error: 'Relay not found' }))
+                    body: b4a.from(JSON.stringify({ error: 'Relay not found' }))
                 };
             }
             console.log(`[RelayServer] Resolved public identifier ${identifier} to relay key ${relayKey.substring(0, 8)}...`);
@@ -1156,7 +1157,7 @@ protocol.handle('/authorize', async (request) => {
             return {
                 statusCode: 200,
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify(result))
+                body: b4a.from(JSON.stringify(result))
             };
         } else {
             console.error('[RelayServer] Failed to disconnect relay:', result.error);
@@ -1164,7 +1165,7 @@ protocol.handle('/authorize', async (request) => {
             return {
                 statusCode: 404,
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify({ error: result.error }))
+                body: b4a.from(JSON.stringify({ error: result.error }))
             };
         }
     } catch (error) {
@@ -1173,7 +1174,7 @@ protocol.handle('/authorize', async (request) => {
         return {
             statusCode: 500,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify({ error: error.message }))
+            body: b4a.from(JSON.stringify({ error: error.message }))
         };
     }
 });
@@ -1202,7 +1203,7 @@ protocol.handle('/authorize', async (request) => {
           return {
             statusCode: 404,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify({ error: 'Relay not found' }))
+            body: b4a.from(JSON.stringify({ error: 'Relay not found' }))
           };
         }
         console.log(`[RelayServer] Resolved public identifier ${identifier} to relay key ${relayKey.substring(0, 8)}...`);
@@ -1211,7 +1212,7 @@ protocol.handle('/authorize', async (request) => {
       // Parse the message
       let nostrMessage;
       if (message && message.type === 'Buffer' && Array.isArray(message.data)) {
-        const messageStr = Buffer.from(message.data).toString('utf8');
+        const messageStr = b4a.from(message.data).toString('utf8');
         try {
           nostrMessage = JSON.parse(messageStr);
         } catch (parseError) {
@@ -1257,7 +1258,7 @@ protocol.handle('/authorize', async (request) => {
               return {
                 statusCode: 403,
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify([
+                body: b4a.from(JSON.stringify([
                   ['NOTICE', 'Authentication required for read access']
                 ]))
               };
@@ -1271,7 +1272,7 @@ protocol.handle('/authorize', async (request) => {
               return {
                 statusCode: 403,
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify([
+                body: b4a.from(JSON.stringify([
                   ['NOTICE', 'Invalid authentication']
                 ]))
               };
@@ -1294,7 +1295,7 @@ protocol.handle('/authorize', async (request) => {
             return {
               statusCode: 200, // Still 200 because it's a valid NOSTR response
               headers: { 'content-type': 'application/json' },
-              body: Buffer.from(JSON.stringify(okResponse))
+              body: b4a.from(JSON.stringify(okResponse))
             };
           }
           
@@ -1308,7 +1309,7 @@ protocol.handle('/authorize', async (request) => {
             return {
               statusCode: 200,
               headers: { 'content-type': 'application/json' },
-              body: Buffer.from(JSON.stringify(okResponse))
+              body: b4a.from(JSON.stringify(okResponse))
             };
           }
           
@@ -1321,7 +1322,7 @@ protocol.handle('/authorize', async (request) => {
             return {
               statusCode: 200,
               headers: { 'content-type': 'application/json' },
-              body: Buffer.from(JSON.stringify(okResponse))
+              body: b4a.from(JSON.stringify(okResponse))
             };
           }
           
@@ -1335,7 +1336,7 @@ protocol.handle('/authorize', async (request) => {
             return {
               statusCode: 200,
               headers: { 'content-type': 'application/json' },
-              body: Buffer.from(JSON.stringify(okResponse))
+              body: b4a.from(JSON.stringify(okResponse))
             };
           }
           
@@ -1359,7 +1360,7 @@ protocol.handle('/authorize', async (request) => {
             return {
               statusCode: 200,
               headers: { 'content-type': 'application/json' },
-              body: Buffer.from(JSON.stringify(okResponse))
+              body: b4a.from(JSON.stringify(okResponse))
             };
           }
         }
@@ -1386,7 +1387,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 200,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(responseBody)
+        body: b4a.from(responseBody)
       };
       
     } catch (error) {
@@ -1398,7 +1399,7 @@ protocol.handle('/authorize', async (request) => {
       return {
         statusCode: 200, // Still 200 for valid NOSTR error response
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify([
+        body: b4a.from(JSON.stringify([
           ['NOTICE', `Error: ${error.message}`]
         ]))
       };
@@ -1426,7 +1427,7 @@ protocol.handle('/authorize', async (request) => {
                 return {
                     statusCode: 404,
                     headers: { 'content-type': 'application/json' },
-                    body: Buffer.from(JSON.stringify(['NOTICE', 'Relay not found']))
+                    body: b4a.from(JSON.stringify(['NOTICE', 'Relay not found']))
                 };
             }
             console.log(`[RelayServer] Resolved public identifier ${identifier} to relay key ${relayKey.substring(0, 8)}...`);
@@ -1460,7 +1461,7 @@ protocol.handle('/authorize', async (request) => {
               return {
                 statusCode: 200, // Return 200 for valid NOSTR NOTICE response
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify([
+                body: b4a.from(JSON.stringify([
                   ['NOTICE', 'Authentication required for read access']
                 ]))
               };
@@ -1474,7 +1475,7 @@ protocol.handle('/authorize', async (request) => {
               return {
                 statusCode: 200, // Return 200 for valid NOSTR NOTICE response
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify([
+                body: b4a.from(JSON.stringify([
                   ['NOTICE', 'Invalid authentication']
                 ]))
               };
@@ -1496,7 +1497,7 @@ protocol.handle('/authorize', async (request) => {
             return {
                 statusCode: 500,
                 headers: { 'content-type': 'application/json' },
-                body: Buffer.from(JSON.stringify(['NOTICE', 'Internal server error: Invalid response format']))
+                body: b4a.from(JSON.stringify(['NOTICE', 'Internal server error: Invalid response format']))
             };
         }
   
@@ -1517,7 +1518,7 @@ protocol.handle('/authorize', async (request) => {
         return {
             statusCode: 200,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify(events))
+            body: b4a.from(JSON.stringify(events))
         };
         
     } catch (error) {
@@ -1526,7 +1527,7 @@ protocol.handle('/authorize', async (request) => {
         return {
             statusCode: 500,
             headers: { 'content-type': 'application/json' },
-            body: Buffer.from(JSON.stringify(['NOTICE', `Error: ${error.message}`]))
+            body: b4a.from(JSON.stringify(['NOTICE', `Error: ${error.message}`]))
         };
     }
 });
@@ -1543,7 +1544,7 @@ protocol.handle('/authorize', async (request) => {
     return {
       statusCode: 200,
       headers: { 'content-type': 'application/json' },
-      body: Buffer.from(JSON.stringify({ 
+      body: b4a.from(JSON.stringify({ 
         status: 'acknowledged',
         timestamp: new Date().toISOString()
       }))
@@ -1787,7 +1788,7 @@ async function registerWithGateway(relayProfileInfo = null) {
           method: 'POST',
           headers: {
               'Content-Type': 'application/json',
-              'Content-Length': Buffer.byteLength(postData)
+              'Content-Length': b4a.byteLength(postData)
           },
           rejectUnauthorized: false // For self-signed certs
       };
@@ -2014,7 +2015,7 @@ export async function startJoinAuthentication(options) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(postData)
+        'Content-Length': b4a.byteLength(postData)
       },
       rejectUnauthorized: false // For self-signed certs in dev
     };
@@ -2071,14 +2072,14 @@ export async function startJoinAuthentication(options) {
       '02' + relayPubkey, // Add compression prefix for noble-secp256k1
       true
     );
-    const keyBuffer = Buffer.from(sharedSecret.slice(1, 33)); // Derive 32-byte key
+    const keyBuffer = b4a.from(sharedSecret.slice(1, 33)); // Derive 32-byte key
     console.log(`[RelayServer] Shared key computed: ${keyBuffer.toString('hex').substring(0, 8)}...`);
 
     // Encrypt the challenge using AES-256-CBC
     const iv = crypto.randomBytes(16);
     const encrypted = nobleSecp256k1.aes.encrypt(challenge, keyBuffer, iv);
-    const ciphertext = Buffer.from(encrypted).toString('base64');
-    const ivBase64 = Buffer.from(iv).toString('base64');
+    const ciphertext = b4a.from(encrypted).toString('base64');
+    const ivBase64 = b4a.from(iv).toString('base64');
     console.log('[RelayServer] Challenge encrypted.');
 
     // Send the encrypted challenge to the verification URL
@@ -2096,7 +2097,7 @@ export async function startJoinAuthentication(options) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(verifyPostData)
+        'Content-Length': b4a.byteLength(verifyPostData)
       },
       rejectUnauthorized: false // For self-signed certs in dev
     };
@@ -2151,7 +2152,7 @@ export async function startJoinAuthentication(options) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(finalPostData)
+        'Content-Length': b4a.byteLength(finalPostData)
       },
       rejectUnauthorized: false // For self-signed certs in dev
     };

--- a/hypertuna-worker/pure-secp256k1-bare.js
+++ b/hypertuna-worker/pure-secp256k1-bare.js
@@ -4,6 +4,7 @@
  */
 
 import crypto from 'bare-crypto';
+import b4a from 'b4a';
 
 // secp256k1 curve parameters
 const CURVE = {
@@ -696,8 +697,8 @@ const nobleSecp256k1 = {
   aes: {
     encrypt: (plaintext, key, iv) => {
       const aes = new AES256CBC();
-      const plaintextBytes = typeof plaintext === 'string' 
-        ? new TextEncoder().encode(plaintext)
+      const plaintextBytes = typeof plaintext === 'string'
+        ? b4a.from(plaintext, 'utf8')
         : plaintext;
       const keyBytes = typeof key === 'string' 
         ? nobleSecp256k1.utils.hexToBytes(key)

--- a/hypertuna-worker/relay-protocol-enhanced.mjs
+++ b/hypertuna-worker/relay-protocol-enhanced.mjs
@@ -2,6 +2,7 @@
 import Protomux from 'protomux';
 import c from 'compact-encoding';
 import { EventEmitter } from 'bare-events';
+import b4a from 'b4a';
 
 const REQUEST_TIMEOUT = 30000; // 30 seconds
 
@@ -11,13 +12,13 @@ const httpMessageEncoding = {
     c.string.preencode(state, m.method || 'GET');
     c.string.preencode(state, m.path || '/');
     c.string.preencode(state, JSON.stringify(m.headers || {}));
-    c.buffer.preencode(state, m.body || Buffer.alloc(0));
+    c.buffer.preencode(state, m.body || b4a.alloc(0));
   },
   encode(state, m) {
     c.string.encode(state, m.method || 'GET');
     c.string.encode(state, m.path || '/');
     c.string.encode(state, JSON.stringify(m.headers || {}));
-    c.buffer.encode(state, m.body || Buffer.alloc(0));
+    c.buffer.encode(state, m.body || b4a.alloc(0));
   },
   decode(state) {
     return {
@@ -33,12 +34,12 @@ const httpResponseEncoding = {
   preencode(state, m) {
     c.uint.preencode(state, m.statusCode || 200);
     c.string.preencode(state, JSON.stringify(m.headers || {}));
-    c.buffer.preencode(state, m.body || Buffer.alloc(0));
+    c.buffer.preencode(state, m.body || b4a.alloc(0));
   },
   encode(state, m) {
     c.uint.encode(state, m.statusCode || 200);
     c.string.encode(state, JSON.stringify(m.headers || {}));
-    c.buffer.encode(state, m.body || Buffer.alloc(0));
+    c.buffer.encode(state, m.body || b4a.alloc(0));
   },
   decode(state) {
     return {
@@ -146,7 +147,7 @@ export class RelayProtocol extends EventEmitter {
       method: message.method,
       path: message.path,
       headers: message.headers || {},
-      body: message.body ? Buffer.from(message.body) : Buffer.alloc(0)
+      body: message.body ? b4a.from(message.body) : b4a.alloc(0)
     };
     
     // Check if we have a handler for this path pattern
@@ -207,7 +208,7 @@ export class RelayProtocol extends EventEmitter {
         id: request.id,
         statusCode: response.statusCode || 200,
         headers: response.headers || {},
-        body: response.body || Buffer.alloc(0)
+        body: response.body || b4a.alloc(0)
       });
     } catch (err) {
       console.error('[RelayProtocol] Handler error:', err);
@@ -215,7 +216,7 @@ export class RelayProtocol extends EventEmitter {
         id: request.id,
         statusCode: 500,
         headers: { 'content-type': 'application/json' },
-        body: Buffer.from(JSON.stringify({ error: err.message }))
+        body: b4a.from(JSON.stringify({ error: err.message }))
       });
     }
   }
@@ -230,7 +231,7 @@ export class RelayProtocol extends EventEmitter {
       const response = {
         statusCode: message.statusCode,
         headers: message.headers || {},
-        body: message.body ? Buffer.from(message.body) : Buffer.alloc(0)
+        body: message.body ? b4a.from(message.body) : b4a.alloc(0)
       };
       
       request.resolve(response);


### PR DESCRIPTION
## Summary
- add `b4a` imports across worker code
- rely on `b4a` for converting strings to Uint8Array
- update AES helper to use `b4a.from`
- replace Buffer-based conversion in relay modules

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877191488b4832aacda71dbe8c1a36e