### PR TITLE
Fix AES key derivation in join auth

### DIFF
--- a/hypertuna-worker/challenge-manager.mjs
+++ b/hypertuna-worker/challenge-manager.mjs
@@ -177,8 +177,8 @@ export class ChallengeManager {
         true
       );
       
-      // Use the same key derivation as the demo - slice from index 1 to 33
-      const keyBuffer = b4a.from(sharedSecret.slice(1, 33));
+      // Use the full shared secret as the AES key
+      const keyBuffer = b4a.from(sharedSecret);
       
       console.log(`[ChallengeManager] Shared key: ${keyBuffer.toString('hex').substring(0, 16)}...`);
       

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -2072,7 +2072,8 @@ export async function startJoinAuthentication(options) {
       '02' + relayPubkey, // Add compression prefix for noble-secp256k1
       true
     );
-    const keyBuffer = b4a.from(sharedSecret.slice(1, 33)); // Derive 32-byte key
+    // Use the full shared secret as the AES key
+    const keyBuffer = b4a.from(sharedSecret);
     console.log(`[RelayServer] Shared key computed: ${keyBuffer.toString('hex').substring(0, 8)}...`);
 
     // Encrypt the challenge using AES-256-CBC


### PR DESCRIPTION
## Summary
- derive ECDH AES key without slicing in `pear-relay-server` and `challenge-manager`

## Testing
- `npm test` *(fails: brittle: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68771f1e5ee8832abcdd4a713fbf4e01