### PR TITLE
Update join auth to derive pubkey

### DIFF
--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -1956,8 +1956,11 @@ async function createGroupJoinRequest(publicIdentifier, privateKey) {
 
 export async function startJoinAuthentication(options) {
   const { publicIdentifier } = options;
-  const userPubkey = config.nostr_pubkey_hex;
   const userNsec = config.nostr_nsec_hex;
+  const userPubkey = NostrUtils.getPublicKey(userNsec);
+  if (config.nostr_pubkey_hex && userPubkey !== config.nostr_pubkey_hex) {
+    console.warn('[RelayServer] Derived pubkey does not match configured pubkey');
+  }
 
   console.log(`[RelayServer] Starting join authentication for: ${publicIdentifier}`);
   console.log(`[RelayServer] Using user pubkey: ${userPubkey.substring(0, 8)}...`);


### PR DESCRIPTION
## Summary
- compute join authentication public key from the configured secret key
- warn if the derived key differs from the configured `nostr_pubkey_hex`

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877298b296c832a8696a7167cfffa80