### PR TITLE
Trim 33-byte ECDH secrets

### DIFF
--- a/hypertuna-worker/challenge-manager.mjs
+++ b/hypertuna-worker/challenge-manager.mjs
@@ -171,13 +171,16 @@ export class ChallengeManager {
       console.log(`[ChallengeManager] Verifying challenge for ${pubkey.substring(0, 8)}...`);
       
       // Compute ECDH shared secret
-      const sharedSecret = await nobleSecp256k1.getSharedSecret(
+      let sharedSecret = await nobleSecp256k1.getSharedSecret(
         this.relayPrivateKey,
         '02' + pubkey, // Add compression prefix
         true
       );
-      
-      // Use the full shared secret as the AES key
+
+      // noble-secp256k1 may return a 33 byte buffer with a leading 0x00.
+      // Slice the first byte so the derived AES key matches the client's.
+      if (sharedSecret.length === 33) sharedSecret = sharedSecret.slice(1);
+
       const keyBuffer = b4a.from(sharedSecret);
       
       console.log(`[ChallengeManager] Shared key: ${keyBuffer.toString('hex').substring(0, 16)}...`);

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -2070,12 +2070,14 @@ export async function startJoinAuthentication(options) {
 
     // Compute the shared secret using ECDH
     console.log('[RelayServer] Computing shared secret for ECDH...');
-    const sharedSecret = await nobleSecp256k1.getSharedSecret(
+    let sharedSecret = await nobleSecp256k1.getSharedSecret(
       userNsec,
       '02' + relayPubkey, // Add compression prefix for noble-secp256k1
       true
     );
-    // Use the full shared secret as the AES key
+    // noble-secp256k1 may return a 33 byte buffer with a leading 0x00.
+    // Trim it so both sides derive the same 32 byte AES key.
+    if (sharedSecret.length === 33) sharedSecret = sharedSecret.slice(1);
     const keyBuffer = b4a.from(sharedSecret);
     console.log(`[RelayServer] Shared key computed: ${keyBuffer.toString('hex').substring(0, 8)}...`);
 


### PR DESCRIPTION
## Summary
- trim leading 0x00 from noble-sec256k1 shared secrets
- handle same case in challenge verification

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772f482d70832ab4656c92385a1157