### PR TITLE
Improve join flow logging

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway.js
@@ -1105,6 +1105,7 @@ app.post('/callback/verify-ownership/:identifier', async (req, res) => {
     // Get session info
     const sessionKey = `${pubkey}-${identifier}`;
     const session = global.joinSessions?.get(sessionKey);
+    console.log(`[${new Date().toISOString()}] Session key: ${sessionKey}`);
     
     if (!session) {
       console.error(`[${new Date().toISOString()}] No session found for ${sessionKey}`);
@@ -1112,8 +1113,9 @@ app.post('/callback/verify-ownership/:identifier', async (req, res) => {
         error: 'Session not found or expired'
       });
     }
-    
+
     console.log(`[${new Date().toISOString()}] Found session for peer: ${session.peerPublicKey.substring(0, 8)}...`);
+    console.log(`[${new Date().toISOString()}] Stored subnet: ${session.subnetHash.substring(0, 8)}...`);
     
     // Find the peer
     const peer = activePeers.find(p => p.publicKey === session.peerPublicKey);
@@ -1131,6 +1133,8 @@ app.post('/callback/verify-ownership/:identifier', async (req, res) => {
       { pubkey, ciphertext, iv },
       connectionPool
     );
+
+    console.log(`[${new Date().toISOString()}] Callback result:`, result);
     
     if (result.success) {
       // Update session with token

--- a/hypertuna-worker/challenge-manager.mjs
+++ b/hypertuna-worker/challenge-manager.mjs
@@ -162,9 +162,10 @@ export class ChallengeManager {
       // Retrieve stored challenge
       const stored = this.store.retrieve(pubkey);
       if (!stored) {
-        return { 
-          success: false, 
-          error: 'Challenge not found or expired' 
+        console.warn(`[ChallengeManager] No challenge found for ${pubkey.substring(0, 8)}...`);
+        return {
+          success: false,
+          error: 'Challenge not found or expired'
         };
       }
       
@@ -198,12 +199,14 @@ export class ChallengeManager {
         // Generate auth token
         const token = this.generateAuthToken(pubkey);
         
+        console.log('[ChallengeManager] Challenge verified successfully');
         return {
           success: true,
           token,
           identifier: stored.identifier
         };
       } else {
+        console.error('[ChallengeManager] Challenge mismatch');
         return {
           success: false,
           error: 'Challenge verification failed'

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -2056,6 +2056,10 @@ export async function startJoinAuthentication(options) {
     // Step 2.3: Handle challenge and verification callback
     const { challenge, relayPubkey, verifyUrl, finalUrl } = joinResponse;
 
+    console.log(`[RelayServer] Challenge: ${challenge.substring(0, 16)}...`);
+    console.log(`[RelayServer] verifyUrl: ${verifyUrl}`);
+    console.log(`[RelayServer] finalUrl: ${finalUrl}`);
+
     if (!challenge || !relayPubkey || !verifyUrl || !finalUrl) {
       throw new Error('Invalid challenge response from gateway. Missing required fields.');
     }
@@ -2087,6 +2091,8 @@ export async function startJoinAuthentication(options) {
     const ciphertext = b4a.from(encrypted).toString('base64');
     const ivBase64 = b4a.from(iv).toString('base64');
     console.log('[RelayServer] Challenge encrypted.');
+    console.log(`[RelayServer] Ciphertext length: ${ciphertext.length}`);
+    console.log(`[RelayServer] IV base64: ${ivBase64}`);
 
     // Send the encrypted challenge to the verification URL
     const verifyGatewayUrl = new URL(verifyUrl);
@@ -2137,6 +2143,9 @@ export async function startJoinAuthentication(options) {
     });
 
     console.log('[RelayServer] Received verification response from gateway:', verifyResponse);
+    if (verifyResponse && verifyResponse.success === false) {
+      console.log(`[RelayServer] Verification failed: ${verifyResponse.error}`);
+    }
 
     // Step 2.4: Finalization callback, token persistence, and success notification
     if (global.sendMessage) {
@@ -2187,6 +2196,7 @@ export async function startJoinAuthentication(options) {
     });
 
     console.log('[RelayServer] Received final response from gateway:', finalResponse);
+    console.log(`[RelayServer] Final authToken: ${finalResponse.authToken ? finalResponse.authToken.substring(0, 16) : 'none'}`);
 
     const { authToken, relayUrl } = finalResponse;
     if (!authToken || !relayUrl) {


### PR DESCRIPTION
## Summary
- log challenge details and encryption data during join flow
- show verification results when verifying a join request
- surface challenge mismatch info in ChallengeManager
- add debug info for gateway callback sessions

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687738c1e314832ab382ef59a64c742f