### PR TITLE
Fix AES padding edge case

### DIFF
--- a/hypertuna-worker/pure-secp256k1-bare.js
+++ b/hypertuna-worker/pure-secp256k1-bare.js
@@ -419,10 +419,13 @@ class AES256CBC {
     if (iv.length !== 16) throw new Error('IV must be 16 bytes');
     
     const expandedKey = this.expandKey(key);
-    const blocks = Math.ceil(plaintext.length / 16);
+    let blocks = Math.ceil(plaintext.length / 16);
+    if (plaintext.length % 16 === 0) {
+      blocks += 1;
+    }
     const padded = new Uint8Array(blocks * 16);
     padded.set(plaintext);
-    
+
     // PKCS#7 padding
     const paddingLength = padded.length - plaintext.length;
     for (let i = plaintext.length; i < padded.length; i++) {


### PR DESCRIPTION
## Summary
- ensure a blank padding block is added when plaintext length is multiple of 16

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775e9cb5d8832aa2a0ccafe262c2a8