### PR TITLE
Handle worker membership updates

### DIFF
--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -566,6 +566,23 @@ function handleWorkerMessage(message) {
       }
       break;
 
+    case 'members-updated':
+      // Relay membership list was updated in the worker
+      if (message.relayKey) {
+        addLog(`Members updated for ${message.relayKey}`, 'status');
+      } else {
+        addLog('Members updated', 'status');
+      }
+
+      // Refresh relay info so UI reflects latest members
+      fetchRelays();
+
+      // If currently viewing a group, refresh the member list
+      if (window.App && typeof window.App.loadGroupMembers === 'function') {
+        window.App.loadGroupMembers();
+      }
+      break;
+
     case 'health-update':
       updateHealthStatus(message.healthState)
       break


### PR DESCRIPTION
## Summary
- listen for `members-updated` messages from the worker
- refresh relay and group views when membership changes

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a08fb2f40832ab1cb6d6afef83dd8