### PR TITLE
Add persistent console log capture

### DIFF
--- a/hypertuna-desktop/console-file-logger.js
+++ b/hypertuna-desktop/console-file-logger.js
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+// Determine storage directory
+const storageDir = (typeof Pear !== 'undefined' && Pear.config && Pear.config.storage) ? Pear.config.storage : '.'
+const logFilePath = join(storageDir, 'desktop-console.log')
+
+function writeLog(level, args) {
+  const message = args.map(arg => {
+    try {
+      return typeof arg === 'string' ? arg : JSON.stringify(arg)
+    } catch {
+      return '[Unserializable]' 
+    }
+  }).join(' ')
+  const line = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${message}\n`
+  fs.appendFile(logFilePath, line).catch(() => {})
+}
+
+for (const level of ['log', 'info', 'warn', 'error']) {
+  const original = console[level].bind(console)
+  console[level] = (...args) => {
+    writeLog(level, args)
+    original(...args)
+  }
+}
+
+export { logFilePath }

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>Hypertuna P2P Relay Server</title>
+    <!-- Capture console output to a persistent log file -->
+    <script type="module" src="console-file-logger.js"></script>
     <!-- Load our main script that imports all modules -->
     <script type="module" src="main.js"></script>
     <!-- Load worker control logic from desktop app -->


### PR DESCRIPTION
## Summary
- capture console output to a file for the desktop app

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8f2f5230832ab882635eb228fc22