### PR TITLE
Remove subnet hash authorization checks

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1760,8 +1760,8 @@ async fetchMultipleProfiles(pubkeys) {
                 addMap.set(pubkey, { ts: event.created_at, roles: actualRoles });
                 this.relevantPubkeys.add(pubkey);
 
-                // If token and subnetHash are present, send to worker for auth data update
-                if (token && subnetHash && window.workerPipe) {
+                // If token is present, send to worker for auth data update
+                if (token && window.workerPipe) {
                     const relayKey = this.publicToInternalMap.get(groupId) || null;
                     const msg = {
                         type: 'update-auth-data',

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -412,12 +412,13 @@ if (workerPipe) {
               console.log('[Worker] Update auth data requested:', message.data);
               if (relayServer) {
                 try {
-                  const { relayKey, publicIdentifier, pubkey, token, subnetHash } = message.data;
+                  const { relayKey, publicIdentifier, pubkey, token, subnetHashes } = message.data;
                   const identifier = relayKey || publicIdentifier;
                   if (!identifier) {
                     throw new Error('No identifier provided for auth data update');
                   }
-                  await updateRelayAuthToken(identifier, pubkey, token, subnetHash);
+                  const hashes = Array.isArray(subnetHashes) ? subnetHashes : (subnetHashes ? [subnetHashes] : []);
+                  await updateRelayAuthToken(identifier, pubkey, token, hashes);
                   sendMessage({
                     type: 'auth-data-updated',
                     identifier: identifier,


### PR DESCRIPTION
## Summary
- stop checking for subnet hashes when processing membership events on desktop
- adjust worker to accept subnet hash arrays and ignore them for auth
- drop subnet hash checks from relay server endpoints

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad003eeac832a8c00910e084a3770