### PR TITLE
Handle join requests via gateway

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2395,22 +2395,26 @@ async fetchMultipleProfiles(pubkeys) {
      * @param {string} inviteCode - Optional invite code for closed groups
      * @returns {Promise<Object>} - Join request event
      */
-    async joinGroup(publicIdentifier, inviteCode = null) {
+    async joinGroup(publicIdentifier, inviteCode = null, options = {}) {
         if (!this.user || !this.user.privateKey) {
             throw new Error('User not logged in');
         }
-        
+
+        const { publish = true } = options;
+
         // This method is now only used for closed groups with an invite code.
         // The worker-driven flow handles open, authenticated joins.
-        // We simply create and publish the join request event.
+        // We simply create the join request event.
         const event = await NostrEvents.createGroupJoinRequest(
             publicIdentifier,
             inviteCode,
             this.user.privateKey
         );
 
-        // Publish the event directly to the relays
-        await this.relayManager.publish(event);
+        if (publish) {
+            // Publish the event directly to the relays
+            await this.relayManager.publish(event);
+        }
 
         return event;
     }

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -469,8 +469,8 @@ class NostrIntegration {
      * @param {string} inviteCode - Optional invite code for closed groups
      * @returns {Promise<Object>} - Join request event
      */
-    async joinGroup(groupId, inviteCode = null) {
-        return await this.client.joinGroup(groupId, inviteCode);
+    async joinGroup(groupId, inviteCode = null, options = {}) {
+        return await this.client.joinGroup(groupId, inviteCode, options);
     }
     
     /**

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -429,6 +429,7 @@
                     <label for="invite-code-input">Invite Code</label>
                     <input type="text" id="invite-code-input" class="form-input" placeholder="Enter invite code">
                 </div>
+                <div id="join-request-status" class="status-message success hidden"></div>
             </div>
             <div class="modal-footer">
                 <button id="btn-cancel-join" class="btn btn-secondary">Cancel</button>


### PR DESCRIPTION
## Summary
- allow `NostrGroupClient.joinGroup` to optionally skip publishing
- wire through options in `NostrIntegration.joinGroup`
- send join request event to gateway in `AppIntegration.sendJoinRequest`
- show join request status message in join modal

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc0c659a0832a979b7a53012d44ee