### PR TITLE
Implement join request flow for closed relays

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1531,8 +1531,9 @@ App.syncHypertunaConfigToFile = async function() {
                 // For open groups, show authentication modal
                 await this.showJoinAuthModal();
             } else {
-                // For closed groups, show invite code modal first
-                this.showJoinModal();
+                // For closed groups, immediately send join request and display status
+                this.showJoinModal(false);
+                await this.sendJoinRequest();
             }
         } catch (e) {
             console.error('Error joining group:', e);
@@ -1798,6 +1799,10 @@ App.syncHypertunaConfigToFile = async function() {
                 if (statusEl) {
                     statusEl.textContent = 'join request received – pending admin approval';
                     statusEl.classList.remove('hidden');
+                }
+                const messageEl = document.getElementById('join-modal-message');
+                if (messageEl) {
+                    messageEl.textContent = 'Join request submitted.';
                 }
             } else {
                 const text = await response.text();

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -433,8 +433,8 @@
                 <button class="modal-close" id="close-join-modal">&times;</button>
             </div>
             <div class="modal-body">
-                <p>This relay requires an invite code to join.</p>
-                <div class="form-group">
+                <p id="join-modal-message">This relay requires an invite code to join.</p>
+                <div id="invite-code-group" class="form-group">
                     <label for="invite-code-input">Invite Code</label>
                     <input type="text" id="invite-code-input" class="form-input" placeholder="Enter invite code">
                 </div>
@@ -1147,10 +1147,24 @@
           },
           
           // Modal methods
-          showJoinModal() {
-              document.getElementById('join-group-modal').classList.add('show');
-              document.getElementById('invite-code-input').value = '';
-              document.getElementById('invite-code-input').focus();
+          showJoinModal(requireInvite = true) {
+              const modal = document.getElementById('join-group-modal');
+              modal.classList.add('show');
+              const inviteGroup = document.getElementById('invite-code-group');
+              const confirmBtn = document.getElementById('btn-confirm-join');
+              const messageEl = document.getElementById('join-modal-message');
+
+              if (requireInvite) {
+                  if (inviteGroup) inviteGroup.classList.remove('hidden');
+                  if (confirmBtn) confirmBtn.classList.remove('hidden');
+                  if (messageEl) messageEl.textContent = 'This relay requires an invite code to join.';
+                  document.getElementById('invite-code-input').value = '';
+                  document.getElementById('invite-code-input').focus();
+              } else {
+                  if (inviteGroup) inviteGroup.classList.add('hidden');
+                  if (confirmBtn) confirmBtn.classList.add('hidden');
+                  if (messageEl) messageEl.textContent = 'Sending join request...';
+              }
           },
           
           closeJoinModal() {


### PR DESCRIPTION
## Summary
- update joinGroup to automatically send a join request for closed relays
- update join modal to handle invite-less requests and show progress
- show confirmation text when join request is submitted

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de1f49df0832aa3579a7258a349dd