### PR TITLE
Add hypertuna tags on invite events

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -440,11 +440,24 @@ class NostrEvents {
      * @param {string} privateKey - Private key for signing
      * @returns {Promise<Object>} - Signed event
      */
-    static async createGroupInviteEvent(publicIdentifier, privateKey) {
+    static async createGroupInviteEvent(publicIdentifier, privateKey, metadata = {}) {
+        const tags = [
+            ['h', publicIdentifier],
+            ['i', 'hypertuna']
+        ];
+
+        if (metadata.name) {
+            tags.push(['name', metadata.name]);
+        }
+
+        if (metadata.about) {
+            tags.push(['about', metadata.about]);
+        }
+
         return this.createEvent(
             this.KIND_GROUP_INVITE_CREATE,
             'Creating invite code',
-            [['h', publicIdentifier]], // Use public identifier
+            tags,
             privateKey
         );
     }

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2642,9 +2642,11 @@ async fetchMultipleProfiles(pubkeys) {
             throw new Error('You must be an admin to create invite codes');
         }
         
+        const group = this.groups.get(groupId) || {};
         const event = await NostrEvents.createGroupInviteEvent(
             groupId,
-            this.user.privateKey
+            this.user.privateKey,
+            group
         );
         
         // Publish the event
@@ -2986,10 +2988,20 @@ async fetchMultipleProfiles(pubkeys) {
         const isPublic = this.groups.get(groupId)?.isPublic || false;
         const payload = { relayUrl, token, relayKey, isPublic };
         const encrypted = NostrUtils.encrypt(this.user.privateKey, pubkey, JSON.stringify(payload));
+
+        const group = this.groups.get(groupId) || {};
+        const tags = [
+            ['h', groupId],
+            ['p', pubkey],
+            ['i', 'hypertuna'],
+            ['name', group.name || ''],
+            ['about', group.about || '']
+        ];
+
         const event = await NostrEvents.createEvent(
             NostrEvents.KIND_GROUP_INVITE_CREATE,
             encrypted,
-            [['h', groupId], ['p', pubkey]],
+            tags,
             this.user.privateKey
         );
         const discoveryRelays = Array.from(this.relayManager.discoveryRelays);


### PR DESCRIPTION
## Summary
- include hypertuna invite tags when creating invites
- pass group metadata through in approveJoinRequest
- keep createGroupInvite in sync with new invite helper

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea84a9c7c832aac5d4a579a77b5e3