### PR TITLE
Handle closed relay invites locally

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1652,11 +1652,14 @@ async fetchMultipleProfiles(pubkeys) {
             const invite = {
                 id: event.id,
                 groupId,
+                publicIdentifier: groupId,
                 inviter: event.pubkey,
                 relayUrl: data.relayUrl,
                 token: data.token,
                 relayKey: data.relayKey,
-                isPublic: data.isPublic !== false
+                isPublic: data.isPublic !== false,
+                name: NostrEvents._getTagValue(event, 'name') || '',
+                about: NostrEvents._getTagValue(event, 'about') || ''
             };
 
             this.invites.set(event.id, invite);
@@ -2943,7 +2946,7 @@ async fetchMultipleProfiles(pubkeys) {
 
         const urlWithToken = invite.relayUrl.includes('token=') ? invite.relayUrl : `${invite.relayUrl}?token=${invite.token}`;
 
-        await this.updateUserRelayListWithAuth(invite.relayKey, urlWithToken, invite.token, invite.isPublic);
+        await this.updateUserRelayListWithAuth(invite.publicIdentifier || invite.groupId, urlWithToken, invite.token, invite.isPublic);
 
         this.invites.delete(inviteId);
         this.emit('invites:update', { invites: this.getInvites() });

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -869,6 +869,29 @@ async function joinRelayInstance(publicIdentifier) {
   });
 }
 
+// Join a relay using data from an invite event
+async function joinRelayFromInvite(relayKey, name = '', description = '', publicIdentifier = '') {
+  return new Promise((resolve, reject) => {
+    if (!workerPipe) {
+      addLog('Worker not running', 'error');
+      return reject(new Error('Worker not running'));
+    }
+
+    try {
+      workerPipe.write(
+        JSON.stringify({
+          type: 'join-relay',
+          data: { relayKey, name, description, publicIdentifier }
+        }) + '\n'
+      );
+      resolve();
+    } catch (err) {
+      addLog(`Failed to join relay from invite: ${err.message}`, 'error');
+      reject(err);
+    }
+  });
+}
+
 // Join an existing relay
 async function joinRelay() {
   const keyInput = document.getElementById('join-relay-key')
@@ -1143,6 +1166,7 @@ window.startWorker = startWorker;
 window.stopWorker = stopWorker;
 window.createRelayInstance = createRelayInstance;
 window.joinRelayInstance = joinRelayInstance;
+window.joinRelayFromInvite = joinRelayFromInvite;
 window.disconnectRelayInstance = disconnectRelay;
 window.debugButtonState = debugButtonState;
 

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -1315,7 +1315,9 @@
           async acceptInvite(inviteId) {
               try {
                   const invite = await this.nostr.client.acceptInvite(inviteId);
-                  if (window.joinRelayInstance) {
+                  if (window.joinRelayFromInvite) {
+                      await window.joinRelayFromInvite(invite.relayKey, invite.name, invite.about, invite.publicIdentifier || invite.groupId);
+                  } else if (window.joinRelayInstance) {
                       await window.joinRelayInstance(invite.relayKey);
                   }
                   this.closeInvitesModal();


### PR DESCRIPTION
## Summary
- keep name/about from invite events
- add `joinRelayFromInvite` to initialize relays with worker
- call the new method when accepting an invite
- pass public identifier when joining from invite

## Testing
- `npm test` *(fails: brittle not found)*
- `cd hypertuna-worker && npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb7a07064832a9cb0a9d5c857d66f