### PR TITLE
Fix invite join token handling

### DIFF
--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -870,7 +870,7 @@ async function joinRelayInstance(publicIdentifier) {
 }
 
 // Join a relay using data from an invite event
-async function joinRelayFromInvite(relayKey, name = '', description = '', publicIdentifier = '') {
+async function joinRelayFromInvite(relayKey, name = '', description = '', publicIdentifier = '', authToken = '') {
   return new Promise((resolve, reject) => {
     if (!workerPipe) {
       addLog('Worker not running', 'error');
@@ -881,7 +881,7 @@ async function joinRelayFromInvite(relayKey, name = '', description = '', public
       workerPipe.write(
         JSON.stringify({
           type: 'join-relay',
-          data: { relayKey, name, description, publicIdentifier }
+          data: { relayKey, name, description, publicIdentifier, authToken }
         }) + '\n'
       );
       resolve();

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -1316,7 +1316,7 @@
               try {
                   const invite = await this.nostr.client.acceptInvite(inviteId);
                   if (window.joinRelayFromInvite) {
-                      await window.joinRelayFromInvite(invite.relayKey, invite.name, invite.about, invite.publicIdentifier || invite.groupId);
+                      await window.joinRelayFromInvite(invite.relayKey, invite.name, invite.about, invite.publicIdentifier || invite.groupId, invite.token);
                   } else if (window.joinRelayInstance) {
                       await window.joinRelayInstance(invite.relayKey);
                   }


### PR DESCRIPTION
## Summary
- allow `joinRelayFromInvite` to pass the invite token
- propagate token to worker and use it when signaling relay initialization
- ensure invite acceptance forwards the token

## Testing
- `npm test --prefix hypertuna-desktop` *(fails: brittle not found)*
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed697bfd0832a8a6431666a7e75f5