### PR TITLE
Handle membership tokens in NostrGroupClient

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1829,6 +1829,11 @@ async fetchMultipleProfiles(pubkeys) {
                 const token = rolesAndAuthData[1]; // The auth token
                 const subnetHashes = rolesAndAuthData.slice(2); // All subsequent elements are subnet hashes
 
+                // If this entry is for the current user and a token is provided
+                if (token && this.user && pubkey === this.user.pubkey) {
+                    this.relayAuthTokens.set(groupId, token);
+                }
+
                 addMap.set(pubkey, { ts: event.created_at, roles: actualRoles });
                 this.relevantPubkeys.add(pubkey);
 

--- a/hypertuna-desktop/test/nostr-group-client.test.js
+++ b/hypertuna-desktop/test/nostr-group-client.test.js
@@ -1,0 +1,34 @@
+import test from 'brittle'
+import NostrGroupClient from '../NostrGroupClient.js'
+
+class DummyRelayManager {
+  constructor () {
+    this.added = []
+  }
+  async addTypedRelay (url, type, id) {
+    this.added.push({ url, type, id })
+  }
+  on () {}
+}
+
+test('store auth token from membership event and use in connection', async t => {
+  global.window = {}
+  const client = new NostrGroupClient(false)
+  client.user = { pubkey: 'alice' }
+  client.relayManager = new DummyRelayManager()
+
+  const event = {
+    kind: 9000,
+    created_at: 0,
+    tags: [
+      ['h', 'group1'],
+      ['p', 'alice', 'member', 'tok123']
+    ]
+  }
+
+  client._processGroupAddUserEvent(event)
+  t.is(client.relayAuthTokens.get('group1'), 'tok123')
+
+  await client.connectToGroupRelay('group1', 'wss://relay.example.com')
+  t.is(client.relayManager.added[0].url, 'wss://relay.example.com?token=tok123')
+})


### PR DESCRIPTION
## Summary
- store membership tokens for the current user when processing a kind `9000` event
- test that tokens are remembered and used when connecting to a relay

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f1a0bde7c832a8d8f6ba9baa25494