### PR TITLE
Fix invite auth token usage

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2991,7 +2991,8 @@ async fetchMultipleProfiles(pubkeys) {
         const token = NostrUtils.generateInviteCode();
         await this.addGroupMember(groupId, pubkey, ['member', token]);
 
-        const relayUrl = this.groupRelayUrls.get(groupId) || '';
+        const storedUrl = this.groupRelayUrls.get(groupId) || '';
+        const relayUrl = this._getBaseRelayUrl(storedUrl);
         const relayKey = this.publicToInternalMap.get(groupId) || null;
         const isPublic = this.groups.get(groupId)?.isPublic || false;
         const payload = { relayUrl, token, relayKey, isPublic };


### PR DESCRIPTION
## Summary
- stop sending admin-authenticated relay URL in invites

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f2f74a2c4832a83a9d478d9e9cf2a