### PR TITLE
Fix invite auth token registration

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -177,21 +177,20 @@ export async function updateRelayAuthToken(identifier, pubkey, token, newSubnetH
 
         if (saved) {
             try {
-                const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
-                const store = getRelayAuthStore();
-                const firstSubnet = newSubnetHashes[0] || null;
-                if (firstSubnet) {
-                    store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
-                    if (profile.public_identifier) {
-                        store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
-                    }
-                    for (const sub of newSubnetHashes.slice(1)) {
-                        store.addSubnet(profile.relay_key, pubkey, sub);
-                        if (profile.public_identifier) {
-                            store.addSubnet(profile.public_identifier, pubkey, sub);
-                        }
-                    }
-                }
+        const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
+        const store = getRelayAuthStore();
+        const firstSubnet = newSubnetHashes[0] || null;
+        // Always add auth entry even when no subnet information is available
+        store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
+        if (profile.public_identifier) {
+            store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
+        }
+        for (const sub of newSubnetHashes.slice(1)) {
+            store.addSubnet(profile.relay_key, pubkey, sub);
+            if (profile.public_identifier) {
+                store.addSubnet(profile.public_identifier, pubkey, sub);
+            }
+        }
             } catch (err) {
                 console.error('[ProfileManager] Failed to update auth store:', err);
             }


### PR DESCRIPTION
## Summary
- ensure auth store is updated even when no subnet information is supplied

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f39180b5c832aa9cf89c8ed67aa7f