### PR TITLE
Fix auth store updates when no subnet hashes

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -179,17 +179,15 @@ export async function updateRelayAuthToken(identifier, pubkey, token, newSubnetH
             try {
                 const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
                 const store = getRelayAuthStore();
-                const firstSubnet = newSubnetHashes[0] || null;
-                if (firstSubnet) {
-                    store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
+                const firstSubnet = newSubnetHashes[0] || '';
+                store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
+                if (profile.public_identifier) {
+                    store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
+                }
+                for (const sub of newSubnetHashes.slice(1)) {
+                    store.addSubnet(profile.relay_key, pubkey, sub);
                     if (profile.public_identifier) {
-                        store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
-                    }
-                    for (const sub of newSubnetHashes.slice(1)) {
-                        store.addSubnet(profile.relay_key, pubkey, sub);
-                        if (profile.public_identifier) {
-                            store.addSubnet(profile.public_identifier, pubkey, sub);
-                        }
+                        store.addSubnet(profile.public_identifier, pubkey, sub);
                     }
                 }
             } catch (err) {

--- a/hypertuna-worker/relay-auth-store.mjs
+++ b/hypertuna-worker/relay-auth-store.mjs
@@ -38,7 +38,7 @@ getAuthByToken(relayKey, token) {
    * @param {string} token - Authentication token
    * @param {string} subnetHash - Initial subnet hash
    */
-  addAuth(relayKey, pubkey, token, subnetHash) {
+  addAuth(relayKey, pubkey, token, subnetHash = '') {
     if (!this.relayAuths.has(relayKey)) {
       this.relayAuths.set(relayKey, new Map());
     }
@@ -46,7 +46,7 @@ getAuthByToken(relayKey, token) {
     const relayAuth = this.relayAuths.get(relayKey);
     relayAuth.set(pubkey, {
       token,
-      allowedSubnets: [subnetHash],
+      allowedSubnets: subnetHash ? [subnetHash] : [],
       createdAt: Date.now(),
       lastUsed: Date.now()
     });


### PR DESCRIPTION
## Summary
- update profile manager to add auth tokens even when subnet hashes are empty
- make `RelayAuthStore.addAuth` handle missing subnet hashes

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688002d7e5a8832aae856c8bde73baf6