### PR TITLE
Merge nested auth config on save

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -393,7 +393,20 @@ export async function saveRelayProfile(relayProfile) {
             }
             
             console.log(`[ProfileManager] Updating existing profile at index ${existingIndex} for ${relayProfile.relay_key}`);
-            profiles[existingIndex] = {...profiles[existingIndex], ...relayProfile};
+            let mergedProfile = { ...profiles[existingIndex], ...relayProfile };
+            if (profiles[existingIndex].auth_config && relayProfile.auth_config) {
+                mergedProfile.auth_config = {
+                    ...profiles[existingIndex].auth_config,
+                    ...relayProfile.auth_config
+                };
+            }
+            if (profiles[existingIndex].auth_tokens && relayProfile.auth_tokens) {
+                mergedProfile.auth_tokens = {
+                    ...profiles[existingIndex].auth_tokens,
+                    ...relayProfile.auth_tokens
+                };
+            }
+            profiles[existingIndex] = mergedProfile;
         } else {
             // Add new profile
             console.log(`[ProfileManager] Adding new profile for ${relayProfile.relay_key}`);

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -3,7 +3,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import os from 'os'
 
-import { updateRelayAuthToken, getAllRelayProfiles } from '../hypertuna-relay-profile-manager-bare.mjs'
+import { updateRelayAuthToken, updateRelayMemberSets, getAllRelayProfiles } from '../hypertuna-relay-profile-manager-bare.mjs'
 
 // Helper to create temporary storage and seed legacy profile
 async function setupLegacyProfile() {
@@ -21,6 +21,20 @@ async function setupLegacyProfile() {
   return tmp
 }
 
+async function setupProfile() {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'relaytest-'))
+  global.Pear = { config: { storage: tmp } }
+  const profile = {
+    relay_key: 'relay1',
+    admin_pubkey: 'admin',
+    members: ['admin'],
+    auth_config: { requiresAuth: true, tokenProtected: true, authorizedUsers: [], auth_adds: [], auth_removes: [] }
+  }
+  await fs.mkdir(tmp, { recursive: true })
+  await fs.writeFile(path.join(tmp, 'relay-profiles.json'), JSON.stringify({ relays: [profile] }, null, 2))
+  return tmp
+}
+
 test('updateRelayAuthToken migrates legacy auth fields', async t => {
   const tmp = await setupLegacyProfile()
   await updateRelayAuthToken('relay1', 'pub1', 'new', ['sub1'])
@@ -28,5 +42,21 @@ test('updateRelayAuthToken migrates legacy auth fields', async t => {
   t.is(profiles[0].auth_adds, undefined)
   t.is(profiles[0].auth_removes, undefined)
   t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', subnets: ['sub1'], ts: profiles[0].auth_config.auth_adds[0].ts }])
+  await fs.rm(tmp, { recursive: true, force: true })
+})
+
+test('concurrent updates merge nested fields', async t => {
+  const tmp = await setupProfile()
+
+  await updateRelayAuthToken('relay1', 'admin', 'admintoken')
+
+  await Promise.all([
+    updateRelayAuthToken('relay1', 'invitee', 'invtoken'),
+    updateRelayMemberSets('relay1', [{ pubkey: 'invitee', ts: Date.now() }], [])
+  ])
+
+  const profiles = await getAllRelayProfiles()
+  const authPubs = profiles[0].auth_config.authorizedUsers.map(a => a.pubkey).sort()
+  t.alike(authPubs, ['admin', 'invitee'])
   await fs.rm(tmp, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary
- merge nested fields when updating existing relay profiles
- add regression test covering concurrent updates to auth tokens and members

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68801246ce74832a91578577e1fc3703