### PR TITLE
Add member actions panel

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1115,6 +1115,14 @@ App.syncHypertunaConfigToFile = async function() {
                 const jrSection = document.getElementById('join-requests-section');
                 if (jrSection) jrSection.classList.add('hidden');
             }
+
+            const memberPanel = document.getElementById('member-actions');
+            if (memberPanel) {
+                memberPanel.classList.toggle(
+                    'hidden',
+                    !(isMember && !isAdmin && group.isOpen)
+                );
+            }
             
             // Update settings form
             const settingsForm = document.getElementById('group-settings-form');

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -206,6 +206,12 @@
                                         <div id="join-request-list" class="join-request-list"></div>
                                     </div>
                                 </div>
+                                <div id="member-actions" class="member-panel hidden">
+                                    <h3>Member Actions</h3>
+                                    <div class="member-actions">
+                                        <button id="btn-member-invite" class="btn btn-secondary btn-small">Invite Members</button>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         
@@ -771,6 +777,13 @@
               const inviteMembers = document.getElementById('btn-invite-members');
               if (inviteMembers) {
                   inviteMembers.addEventListener('click', () => {
+                      this.createInvite();
+                  });
+              }
+
+              const memberInvite = document.getElementById('btn-member-invite');
+              if (memberInvite) {
+                  memberInvite.addEventListener('click', () => {
                       this.createInvite();
                   });
               }


### PR DESCRIPTION
## Summary
- add Member Actions block under the Members tab
- hook up the new button to create invites
- show the panel for open groups when the user is a non-admin member

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688054b6316c832ab97fbb5e0edcc07b