### PR TITLE
Add inviteMembers integration

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -2766,9 +2766,8 @@ App.saveInviteMembers = async function() {
     btn.disabled = true;
 
     try {
-        for (const pubkey of this.pendingInvites) {
-            await this.nostr.approveJoinRequest(this.currentGroupId, pubkey);
-        }
+        const pubkeys = Array.from(this.pendingInvites);
+        await this.nostr.inviteMembers(this.currentGroupId, pubkeys);
 
         alert('Invites sent successfully!');
         this.closeInviteMembersModal();

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -540,6 +540,10 @@ class NostrIntegration {
         return await this.client.approveJoinRequest(groupId, pubkey);
     }
 
+    async inviteMembers(groupId, pubkeys = []) {
+        return await this.client.inviteMembers(groupId, pubkeys);
+    }
+
     rejectJoinRequest(groupId, pubkey) {
         this.client.rejectJoinRequest(groupId, pubkey);
     }


### PR DESCRIPTION
## Summary
- add `inviteMembers` to `NostrIntegration`
- use the new method from `saveInviteMembers`

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in worker *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68806336be2c832ab53a906f407ec9e2