### PR TITLE
Enforce invite permissions

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1123,6 +1123,12 @@ App.syncHypertunaConfigToFile = async function() {
                     !(isMember && !isAdmin && group.isOpen)
                 );
             }
+
+            const adminInviteBtn = document.getElementById('btn-invite-members');
+            if (adminInviteBtn) adminInviteBtn.disabled = !isAdmin;
+
+            const memberInviteBtn = document.getElementById('btn-member-invite');
+            if (memberInviteBtn) memberInviteBtn.disabled = !(isMember && group.isOpen);
             
             // Update settings form
             const settingsForm = document.getElementById('group-settings-form');

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -3027,6 +3027,22 @@ async fetchMultipleProfiles(pubkeys) {
      * @returns {Promise<Array<Object>>} - Array of invite events
      */
     async inviteMembers(groupId, pubkeys = []) {
+        if (!this.user || !this.user.privateKey) {
+            throw new Error('User not logged in');
+        }
+
+        const group = this.groups.get(groupId);
+        if (!group) {
+            throw new Error('Group not found');
+        }
+
+        const isAdmin = this.isGroupAdmin(groupId, this.user.pubkey);
+        const isMember = this.isGroupMember(groupId, this.user.pubkey);
+
+        if (!isAdmin && !(group.isOpen && isMember)) {
+            throw new Error('You do not have permission to invite members');
+        }
+
         const inviteEvents = [];
         const groupRelayUrl = this.groupRelayUrls.get(groupId);
 


### PR DESCRIPTION
## Summary
- validate user permissions in `inviteMembers`
- disable invite buttons unless the user can invite

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880657def18832a89e9dbe4d0658ea7