### PR TITLE
Add URL tagging for group messages

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -128,10 +128,18 @@ class NostrEvents {
      * @returns {Promise<Object>} - Signed event
      */
     static async createTextNote(content, tags, privateKey) {
+        const eventTags = Array.isArray(tags) ? tags : [];
+        const urls = NostrUtils.extractUrls(content);
+        for (const url of urls) {
+            if (!eventTags.some(t => t[0] === 'r' && t[1] === url)) {
+                eventTags.push(['r', url]);
+            }
+        }
+
         return this.createEvent(
             this.KIND_TEXT_NOTE,
             content,
-            tags,
+            eventTags,
             privateKey
         );
     }

--- a/hypertuna-desktop/NostrUtils.js
+++ b/hypertuna-desktop/NostrUtils.js
@@ -263,6 +263,18 @@ export class NostrUtils {
         }
         return result;
     }
+
+    /**
+     * Extract all HTTP/HTTPS URLs from a string
+     * @param {string} text - Text to search
+     * @returns {Array<string>} - Array of URLs
+     */
+    static extractUrls(text) {
+        if (!text) return [];
+        const regex = /https?:\/\/[^\s]+/g;
+        const matches = text.match(regex);
+        return matches ? Array.from(new Set(matches)) : [];
+    }
     
     /**
      * Get previous event references for timeline threading

--- a/hypertuna-desktop/test/nostr-events.test.js
+++ b/hypertuna-desktop/test/nostr-events.test.js
@@ -1,0 +1,17 @@
+import test from 'brittle'
+
+// dynamic import after setting window
+
+// simple private key for signing
+const privKey = '1'.repeat(64)
+
+// ensure window exists before importing modules
+
+
+test('group message content URLs generate r tags', async t => {
+  global.window = {}
+  const { default: NostrEvents } = await import('../NostrEvents.js')
+  const event = await NostrEvents.createGroupMessage('group1', 'hello https://example.com/page', [], privKey)
+  const hasTag = event.tags.some(tag => tag[0] === 'r' && tag[1] === 'https://example.com/page')
+  t.ok(hasTag)
+})


### PR DESCRIPTION
## Summary
- add new `extractUrls` utility to find HTTP URLs
- include reference tags for URLs when creating text notes
- test that group messages with URLs include `r` tags

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881753edff8832a8da209116c59017a