### PR TITLE
Add file upload to message composer

### DIFF
--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -178,6 +178,7 @@
                                 <div class="message-input-container">
                                     <div class="message-input-wrapper">
                                         <textarea id="message-input" class="message-input" placeholder="Type a message..." rows="1"></textarea>
+                                        <input type="file" id="message-file" accept="*/*">
                                         <button id="btn-send-message" class="send-btn" aria-label="Send message">
                                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                                 <line x1="22" y1="2" x2="11" y2="13"></line>

--- a/hypertuna-desktop/styles.css
+++ b/hypertuna-desktop/styles.css
@@ -776,6 +776,12 @@ body {
     transform: scale(0.95);
 }
 
+/* File input next to message composer */
+#message-file {
+    height: 2.5rem;
+    align-self: flex-end;
+}
+
 /* Members Tab */
 .members-container {
     flex: 1;


### PR DESCRIPTION
## Summary
- allow attaching files in chat composer by adding a file input next to the textarea
- style the file input so it lines up with the send button

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d92aabb4832a9787822515ae7343