### PR TITLE
Add support for file uploads in group messages

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1987,10 +1987,11 @@ App.syncHypertunaConfigToFile = async function() {
             fileInput.disabled = true;
             sendButton.disabled = true;
             
-            await this.nostr.sendGroupMessage(this.currentGroupId, {
-                text: messageText,
+            await this.nostr.sendGroupMessage(
+                this.currentGroupId,
+                messageText,
                 filePath
-            });
+            );
             
             // Clear inputs
             messageInput.value = '';

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2599,7 +2599,7 @@ async fetchMultipleProfiles(pubkeys) {
      * @param {string} content - Message content
      * @returns {Promise<Object>} - Message event
      */
-    async sendGroupMessage(groupId, content) {
+    async sendGroupMessage(groupId, content, filePath = '') {
         if (!this.user || !this.user.privateKey) {
             throw new Error('User not logged in');
         }
@@ -2621,7 +2621,8 @@ async fetchMultipleProfiles(pubkeys) {
             groupId,
             content,
             previousRefs,
-            this.user.privateKey
+            this.user.privateKey,
+            filePath
         );
         
         // Publish only to the group's relay

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -502,8 +502,8 @@ class NostrIntegration {
      * @param {string} content - Message content
      * @returns {Promise<Object>} - Message event
      */
-    async sendGroupMessage(groupId, content) {
-        return await this.client.sendGroupMessage(groupId, content);
+    async sendGroupMessage(groupId, content, filePath = '') {
+        return await this.client.sendGroupMessage(groupId, content, filePath);
     }
     
     /**


### PR DESCRIPTION
## Summary
- allow passing a file path when sending group messages
- generate drive download URLs inside `createTextNote`
- propagate file path through Nostr group message helpers
- adjust desktop app integration to new method signature

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882db8426a4832ab20c771c51aa468a