### PR TITLE
Add Hyperdrive storage to relays

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -827,9 +827,17 @@ export async function updateRelaySubscriptions(relayKey, connectionKey, activeSu
     if (!relayManager) {
       throw new Error(`Relay not found: ${relayKey}`);
     }
-    
+
     return relayManager.updateSubscriptions(connectionKey, activeSubscriptionsUpdated);
   }
+
+export async function writeFile(relayKey, localPath, fileId) {
+    const relayManager = activeRelays.get(relayKey);
+    if (!relayManager) {
+        throw new Error(`Relay not found: ${relayKey}`);
+    }
+    return relayManager.writeFile(localPath, fileId);
+}
 
 /**
  * Get the members list for a relay

--- a/hypertuna-worker/package.json
+++ b/hypertuna-worker/package.json
@@ -38,6 +38,8 @@
         "hyperbee": "^2.13.4",
         "hypercore": "^10.25.0",
         "hypercore-crypto": "^3.4.0",
+        "hyperblobs": "^2.8.0",
+        "hyperdrive": "^13.0.1",
         "hyperswarm": "^4.11.7",
         "pear-interface": "^1.0.0",
         "protomux": "^3.10.1",


### PR DESCRIPTION
## Summary
- create a Hyperdrive for each relay with Hyperbee/Hyperblobs
- replicate the drive across peers on swarm connection
- expose `writeFile` to push local files into the drive
- include Hyperdrive/Hyperblobs in worker dependencies

## Testing
- `npm test --silent` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ddc72f74832a9ef8a9c63fede724