### PR TITLE
Fix hyperdrive initialization

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -126,13 +126,13 @@ export class RelayManager {
         // ==============================
         // Hyperdrive Setup (multiwriter)
         // ==============================
-        const db = new Hyperbee(this.store.get('drive-db'), {
+        const db = new Hyperbee(this.store.get({ name: 'drive-db' }), {
           keyEncoding: 'utf-8',
           valueEncoding: 'json',
           metadata: { contentFeed: null },
           extension: false
         });
-        const blobs = new Hyperblobs(this.store.get('drive-blobs'));
+        const blobs = new Hyperblobs(this.store.get({ name: 'drive-blobs' }));
         this.drive = new Hyperdrive(this.store, { _db: db });
         this.drive.blobs = blobs;
         await this.drive.ready();


### PR DESCRIPTION
## Summary
- prevent passing bare strings to corestore.get when initializing the relay's multiwriter hyperdrive

## Testing
- `npm test` *(fails: brittle not found because dependencies cannot be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882d4eff130832aa49231d4184e0325