### PR TITLE
Add debug logging for Hyperdrive file ops

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -832,8 +832,10 @@ export async function updateRelaySubscriptions(relayKey, connectionKey, activeSu
   }
 
 export async function writeFile(relayKey, localPath, fileId) {
+    console.log(`[RelayAdapter] writeFile for relay ${relayKey} -> ${fileId}`);
     const relayManager = activeRelays.get(relayKey);
     if (!relayManager) {
+        console.error('[RelayAdapter] Relay not found for writeFile');
         throw new Error(`Relay not found: ${relayKey}`);
     }
     return relayManager.writeFile(localPath, fileId);

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -483,12 +483,14 @@ if (workerPipe) {
                 try {
                   const { relayKey, filePath, fileId } = message.data;
                   await writeFile(relayKey, filePath, fileId);
+                  console.log(`[Worker] File ${fileId} uploaded for relay ${relayKey}`);
                   sendMessage({
                     type: 'file-uploaded',
                     relayKey,
                     fileId
                   });
                 } catch (err) {
+                  console.error('[Worker] Failed to upload file:', err);
                   sendMessage({
                     type: 'error',
                     message: `Failed to upload file: ${err.message}`

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -1579,6 +1579,7 @@ protocol.handle('/authorize', async (request) => {
     const fileId = request.params.file;
 
     console.log(`[RelayServer] Drive file requested: ${identifier}/${fileId}`);
+    console.log(`[RelayServer] Looking up relay manager for ${identifier}`);
 
     try {
       let relayKey = identifier;
@@ -1604,7 +1605,7 @@ protocol.handle('/authorize', async (request) => {
           body: b4a.from(JSON.stringify({ error: 'File not found' }))
         };
       }
-
+      console.log(`[RelayServer] Fetching file ${fileId} from drive`);
       const data = await relayManager.drive.get(fileId);
       if (!data) {
         updateMetrics(false);
@@ -1614,6 +1615,8 @@ protocol.handle('/authorize', async (request) => {
           body: b4a.from(JSON.stringify({ error: 'File not found' }))
         };
       }
+
+      console.log(`[RelayServer] Retrieved file ${fileId} (${data.length} bytes)`);
 
       updateMetrics(true);
       return {


### PR DESCRIPTION
## Summary
- log Hyperdrive initialization metadata
- log replication steps for Autobase and Hyperdrive
- log writes to the Hyperdrive
- log adapter requests to write files
- log worker upload success/failure
- log drive fetches in the relay server

## Testing
- `npm test` (fails: `brittle` not found)
- `npx brittle test/*.test.js` (fails: 403 Forbidden)

------
https://chatgpt.com/codex/tasks/task_e_688308d984a4832a8d5d9e8f5d70a90c