### PR TITLE
Add file upload hooks to group messages

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -137,10 +137,13 @@ class NostrEvents {
             }
         }
 
-        let fileUrl = null;
+        let fileId = null;
         if (filePath) {
-            const fileId = NostrUtils.generateRandomId();
-            const ext = filePath.split('.').pop();
+            const baseId = NostrUtils.generateRandomId();
+            const extPart = filePath.split('.').pop();
+            const ext = extPart && extPart !== filePath ? `.${extPart}` : '';
+            fileId = `${baseId}${ext}`;
+
             let gatewayDomain;
             try {
                 gatewayDomain = new URL(HypertunaUtils.DEFAULT_GATEWAY_URL).hostname;
@@ -149,7 +152,7 @@ class NostrEvents {
             }
 
             const publicIdentifier = eventTags.find(t => t[0] === 'h')?.[1] || '';
-            fileUrl = `https://${gatewayDomain}/drive/${publicIdentifier}/${fileId}${ext ? `.${ext}` : ''}`;
+            const fileUrl = `https://${gatewayDomain}/drive/${publicIdentifier}/${fileId}`;
             eventTags.push(['r', fileUrl, 'hypertuna:drive']);
             eventTags.push(['i', 'hypertuna:drive']);
         }
@@ -161,7 +164,7 @@ class NostrEvents {
             privateKey
         );
 
-        return event;
+        return { event, fileId };
     }
     
     /**

--- a/hypertuna-desktop/test/nostr-events.test.js
+++ b/hypertuna-desktop/test/nostr-events.test.js
@@ -11,7 +11,7 @@ const privKey = '1'.repeat(64)
 test('group message content URLs generate r tags', async t => {
   global.window = {}
   const { default: NostrEvents } = await import('../NostrEvents.js')
-  const event = await NostrEvents.createGroupMessage('group1', 'hello https://example.com/page', [], privKey)
+  const { event } = await NostrEvents.createGroupMessage('group1', 'hello https://example.com/page', [], privKey)
   const hasTag = event.tags.some(tag => tag[0] === 'r' && tag[1] === 'https://example.com/page')
   t.ok(hasTag)
 })


### PR DESCRIPTION
## Summary
- return `{ event, fileId }` from `NostrEvents.createTextNote`
- pass fileId through `NostrEvents.createGroupMessage`
- trigger worker `upload-file` message in `NostrGroupClient.sendGroupMessage`
- update unit test for new return type

## Testing
- `npm test --silent` *(fails: brittle not found)*
- `npm test --silent` in `hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831189b5b0832ab28368ad67d6b51a