### PR TITLE
Update file upload note handling

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -138,6 +138,7 @@ class NostrEvents {
         }
 
         let fileId = null;
+        let finalContent = content;
         if (filePath) {
             const baseId = NostrUtils.generateRandomId();
             const extPart = filePath.split('.').pop();
@@ -155,11 +156,17 @@ class NostrEvents {
             const fileUrl = `https://${gatewayDomain}/drive/${publicIdentifier}/${fileId}`;
             eventTags.push(['r', fileUrl, 'hypertuna:drive']);
             eventTags.push(['i', 'hypertuna:drive']);
+
+            // Append the file URL to the content so media loads in the UI
+            if (finalContent && !/\s$/.test(finalContent)) {
+                finalContent += ' ';
+            }
+            finalContent += fileUrl;
         }
 
         const event = await this.createEvent(
             this.KIND_TEXT_NOTE,
-            content,
+            finalContent,
             eventTags,
             privateKey
         );


### PR DESCRIPTION
## Summary
- append uploaded file URLs to the message content body so they render just like pasted links

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883211acfcc832a985aaff8028b664d