### PR TITLE
Add drive key fields to profile schema

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -100,6 +100,14 @@ function ensureProfileSchema(profile) {
         profile.isOpen = false;
     }
 
+    if (profile.drive_key === undefined) {
+        profile.drive_key = null;
+    }
+
+    if (profile.drive_discovery_key === undefined) {
+        profile.drive_discovery_key = null;
+    }
+
     return profile;
 }
 

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -88,3 +88,13 @@ test('concurrent member set updates do not lose updates', async t => {
   t.alike(members, ['alice', 'bob'])
   await fs.rm(tmp, { recursive: true, force: true })
 })
+
+test('profiles include drive fields after load', async t => {
+  const tmp = await setupProfile()
+  const profiles = await getAllRelayProfiles()
+  t.ok('drive_key' in profiles[0])
+  t.ok('drive_discovery_key' in profiles[0])
+  t.is(profiles[0].drive_key, null)
+  t.is(profiles[0].drive_discovery_key, null)
+  await fs.rm(tmp, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary
- include `drive_key` and `drive_discovery_key` defaults in profile schema
- update profile manager tests for new fields

## Testing
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883f62e342c832ab65c0708ad71f3b5