### PR TITLE
Add file actions to relay apply

### DIFF
--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -192,6 +192,18 @@ export default class NostrRelay extends Autobee {
             const key = b4a.from(subscriptionData.connection, 'hex');
             logWithTimestamp(`NostrRelay.apply: Storing subscription data for connection: ${subscriptionData.connection}`);
             await b.put(key, op.subscriptions);
+        } else if (op.type === 'add-file') {
+            const record = op.record || {};
+            logWithTimestamp('NostrRelay.apply: Adding file', record);
+            if (record.key && record.data) {
+                await view.put(record.key, b4a.from(record.data));
+            }
+        } else if (op.type === 'remove-file') {
+            const record = op.record || {};
+            logWithTimestamp('NostrRelay.apply: Removing file', record);
+            if (record.key) {
+                await view.del(record.key);
+            }
         }
     }
   


### PR DESCRIPTION
## Summary
- handle `add-file` and `remove-file` actions inside `NostrRelay.apply`
- confirm `NostrRelay` is opened with a Hyperdrive instance

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883fb5cb6c4832ab2f59182a6fab2ca