### PR TITLE
Use autobase to store files

### DIFF
--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -196,7 +196,7 @@ export default class NostrRelay extends Autobee {
             const record = op.record || {};
             logWithTimestamp('NostrRelay.apply: Adding file', record);
             if (record.key && record.data) {
-                await view.put(record.key, b4a.from(record.data));
+                await view.put(record.key, b4a.from(record.data, 'base64'));
             }
         } else if (op.type === 'remove-file') {
             const record = op.record || {};

--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -310,8 +310,14 @@ export class RelayManager {
       }
 
       try {
-        await this.drive.put(driveKey, data);
-        console.log(`[RelayManager] Stored file ${driveKey} in drive. Version now ${this.drive.version}`);
+        await this.relay.append({
+          type: 'add-file',
+          record: {
+            key: driveKey,
+            data: data.toString('base64')
+          }
+        });
+        console.log(`[RelayManager] Appended add-file operation for ${driveKey}`);
       } catch (err) {
         console.error('[RelayManager] Error storing file:', err);
         throw err;


### PR DESCRIPTION
## Summary
- add-file entries go through the Autobase log in `RelayManager.writeFile`
- decode base64 content when applying 'add-file' ops

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883fd1bef54832a89407fb76bfa9acb