### PR TITLE
Persist drive keys and document migration

### DIFF
--- a/hypertuna-worker/docs/migrate-single-writer-drive.md
+++ b/hypertuna-worker/docs/migrate-single-writer-drive.md
@@ -1,0 +1,25 @@
+# Migrating a Single Writer Drive
+
+This worker originally stored relay files in a single‑writer Hyperdrive. Recent
+versions use a multiwriter drive so that multiple peers can append data. Existing
+drives can be migrated by re-uploading each file to the new multiwriter drive.
+
+1.  Join your relay using the current worker so it creates a new profile with a
+    multiwriter drive.
+2.  For every file from the old drive, call the `writeFile` helper exposed by the
+    worker:
+
+    ```js
+    import { writeFile } from './hypertuna-relay-manager-adapter.mjs'
+
+    // relayKey is the key of the relay profile
+    // localPath points to the file on disk
+    // fileId is the identifier used when serving the file
+    await writeFile(relayKey, localPath, fileId)
+    ```
+
+    This method appends an `add-file` operation to the multiwriter drive.
+3.  Once all files are uploaded you can remove the old single-writer drive.
+
+The `writeFile` API ensures the HTTP retrieval key matches the stored key and
+can be used repeatedly to populate a new drive from existing content.

--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -365,8 +365,8 @@ export async function getRelayProfileByPublicIdentifier(publicIdentifier) {
 /**
  * Add or update a relay profile in the storage file
  * @param {Object} relayProfile - The relay profile to add or update
- * @returns {Promise<boolean>} - True if successful, false otherwise
- */
+ * @returns {Promise<Object|null>} - The saved profile or null on failure
+*/
 export async function saveRelayProfile(relayProfile) {
     return withProfileLock(() => _saveRelayProfile(relayProfile));
 }
@@ -462,11 +462,11 @@ async function _saveRelayProfile(relayProfile) {
             console.error('[ProfileManager] Failed to update relay adapter maps:', err);
         }
 
-        return true;
+        return relayProfile;
     } catch (error) {
         console.error(`[ProfileManager] Error saving relay profile:`, error);
         console.error(error.stack);
-        return false;
+        return null;
     }
 }
 
@@ -583,10 +583,11 @@ export async function updateAutoConnectSetting(relayKey, autoConnect) {
         profile.updated_at = new Date().toISOString();
         
         // Save the updated profile
-        const success = await saveRelayProfile(profile);
-        console.log(`[ProfileManager] Profile save result for ${relayKey}: ${success}`);
-        
-        return success;
+        const saved = await saveRelayProfile(profile);
+        const ok = !!saved;
+        console.log(`[ProfileManager] Profile save result for ${relayKey}: ${ok}`);
+
+        return ok;
     } catch (error) {
         console.error(`[ProfileManager] Error updating auto-connect setting for ${relayKey}:`, error);
         console.error(error.stack);

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -3,7 +3,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import os from 'os'
 
-import { updateRelayAuthToken, updateRelayMemberSets, getAllRelayProfiles } from '../hypertuna-relay-profile-manager-bare.mjs'
+import { updateRelayAuthToken, updateRelayMemberSets, getAllRelayProfiles, saveRelayProfile } from '../hypertuna-relay-profile-manager-bare.mjs'
 
 // Helper to create temporary storage and seed legacy profile
 async function setupLegacyProfile() {
@@ -96,5 +96,21 @@ test('profiles include drive fields after load', async t => {
   t.ok('drive_discovery_key' in profiles[0])
   t.is(profiles[0].drive_key, null)
   t.is(profiles[0].drive_discovery_key, null)
+  await fs.rm(tmp, { recursive: true, force: true })
+})
+
+test('saveRelayProfile persists drive fields', async t => {
+  const tmp = await setupProfile()
+  const profilePath = path.join(tmp, 'relay-profiles.json')
+
+  // Save a new minimal profile without drive fields
+  await saveRelayProfile({ relay_key: 'relay2', name: 'Test Relay' })
+
+  const raw = JSON.parse(await fs.readFile(profilePath, 'utf8'))
+  t.ok('drive_key' in raw.relays[1])
+  t.ok('drive_discovery_key' in raw.relays[1])
+  t.is(raw.relays[1].drive_key, null)
+  t.is(raw.relays[1].drive_discovery_key, null)
+
   await fs.rm(tmp, { recursive: true, force: true })
 })


### PR DESCRIPTION
## Summary
- persist `drive_key` and `drive_discovery_key` when saving profiles
- update auto-connect helper to handle new return value
- test persistence of drive fields when saving
- document how to migrate a single writer drive to the new multiwriter format

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884015d6b88832a8e7fb1b8a00a5911