### PR TITLE
Fix hyperdrive initialization order

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -155,13 +155,15 @@ export class RelayManager {
         this.relay.on('error', console.error);
         
         await this.relay.ready();
+        // Ensure the view is opened so that the open() handler assigns
+        // this.drive before we try to access it.
+        await this.relay.update();
         await this.drive.ready();
         
         console.log(`[RelayManager] Hyperdrive ready in ${this.storageDir}`);
         console.log(`[RelayManager] Drive key: ${b4a.toString(this.drive.key, 'hex')}`);
         console.log(`[RelayManager] Drive version: ${this.drive.version}`);
         
-        await this.relay.update();
 
         this.relay.view.core.on('append', async () => {
           if (this.relay.view.version === 1) return;


### PR DESCRIPTION
## Summary
- ensure hyperdrive view is opened before calling `drive.ready`

## Testing
- `npm test --silent --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68835c8ab908832a847994b7aa3d8cc6