### PR TITLE
Ensure drive replication after ready

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -308,7 +308,9 @@ export class RelayManager {
               }
 
               if (this.drive) {
+                await this.drive.ready();
                 this.drive.replicate(connection);
+                console.log('[RelayManager] Drive replication started with peer writer', writerKey || peerKey.substring(0, 16));
               }
             }
 
@@ -328,8 +330,10 @@ export class RelayManager {
         console.log('[RelayManager] Replicating Autobase with peer');
         this.relay.replicate(connection);
         if (this.drive) {
+          await this.drive.ready();
           console.log('[RelayManager] Replicating Hyperdrive with peer');
           this.drive.replicate(connection);
+          console.log('[RelayManager] Hyperdrive replication stream established with peer', peerKey.substring(0, 16));
         }
       });
     }

--- a/hypertuna-worker/test/drive-replication.test.js
+++ b/hypertuna-worker/test/drive-replication.test.js
@@ -1,0 +1,42 @@
+import test from 'brittle'
+import { EventEmitter } from 'events'
+import { RelayManager } from '../hypertuna-relay-manager-bare.mjs'
+
+class TestRelayManager extends RelayManager {
+  constructor() {
+    super('.', [])
+  }
+
+  // override to avoid hyperswarm usage
+  initializeFake() {
+    this.swarm = new EventEmitter()
+    this.drive = {
+      ready: async () => {},
+      replicate: () => {}
+    }
+    this.relay = { replicate: () => {} }
+    this.peers = new Map()
+    this.setupSwarmListeners()
+  }
+}
+
+test('drive replicates after ready on peer connection', async t => {
+  const manager = new TestRelayManager()
+  manager.initializeFake()
+
+  let readyCalled = false
+  let replicateCalled = false
+
+  manager.drive.ready = async () => {
+    readyCalled = true
+  }
+  manager.drive.replicate = () => {
+    replicateCalled = true
+    t.ok(readyCalled, 'drive.ready called before replicate')
+  }
+
+  const handler = manager.swarm.listeners('connection')[0]
+  await handler({}, { publicKey: Buffer.alloc(32) })
+
+  t.ok(replicateCalled)
+})


### PR DESCRIPTION
## Summary
- wait for `drive.ready()` before replicating connections
- log replication start and peer info
- add `drive-replication.test.js` test covering connection replication order

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688420e64884832aa661c9ea91a6d465