### PR TITLE
Add tests for relay initialization

### DIFF
--- a/hypertuna-worker/test/nostr-relay-open.test.js
+++ b/hypertuna-worker/test/nostr-relay-open.test.js
@@ -1,0 +1,17 @@
+import test from 'brittle'
+import NostrRelay from '../hypertuna-relay-event-processor.mjs'
+
+// Ensure that a custom open function passed to the constructor is executed.
+test('custom open function is executed', async t => {
+  let called = false
+  const relay = new NostrRelay(null, null, {
+    open () {
+      called = true
+      return { ready: async () => {} }
+    },
+    verifyEvent: async () => true
+  })
+
+  await relay.ready()
+  t.ok(called)
+})

--- a/hypertuna-worker/test/relay-manager-init.test.js
+++ b/hypertuna-worker/test/relay-manager-init.test.js
@@ -1,0 +1,23 @@
+import test from 'brittle'
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+import { RelayManager } from '../hypertuna-relay-manager-bare.mjs'
+
+class TestRelayManager extends RelayManager {
+  setupSwarmListeners () {
+    // override to avoid hyperswarm usage during tests
+  }
+  async initRelay () {
+    // skip initialization events
+    return null
+  }
+}
+
+test('initialize creates a drive', async t => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'relaymgr-'))
+  const mgr = new TestRelayManager(dir, [])
+  await mgr.initialize()
+  t.ok(mgr.drive)
+  await fs.rm(dir, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary
- test that a custom `open` handler for `NostrRelay` executes
- test that `RelayManager.initialize()` sets up the drive

## Testing
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*
- `npm test --prefix hypertuna-desktop` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842209c5e4832a81d9e8303e440574