### PR TITLE
Fix hyperdrive readiness order

### DIFF
--- a/autobase-hyperdrive-example/README.md
+++ b/autobase-hyperdrive-example/README.md
@@ -49,9 +49,10 @@ this.relay = new NostrRelay(this.store, this.bootstrap, {
 
 await this.relay.ready()
 await this.relay.update() // ensures open() runs
+// replicate the drive with a peer before awaiting drive.ready()
 ```
 
-The `_createHyperdriveView` helper constructs a `Hyperdrive` with an internal `Hyperbee` database and `Hyperblobs` store. After `update()` the drive is ready for reads and writes.
+The `_createHyperdriveView` helper constructs a `Hyperdrive` with an internal `Hyperbee` database and `Hyperblobs` store. The drive must replicate with a peer to fetch its header before `await drive.ready()` will succeed.
 
 ## Multiwriter Replication Configuration
 

--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -170,14 +170,6 @@ export class RelayManager {
           console.log('[RelayManager] Reusing existing Hyperdrive view.');
         }
 
-        if (this.drive) {
-          await this.drive.ready();
-        }
-        
-        console.log(`[RelayManager] Hyperdrive ready in ${this.storageDir}`);
-        console.log(`[RelayManager] Drive key: ${b4a.toString(this.drive.key, 'hex')}`);
-        console.log(`[RelayManager] Drive version: ${this.drive.version}`);
-        
 
         this.relay.view.core.on('append', async () => {
           if (this.relay.view.version === 1) return;
@@ -279,8 +271,11 @@ export class RelayManager {
                   console.log('[RelayManager] Reusing existing Hyperdrive view.');
                 }
 
+
                 if (this.drive) {
-                  await this.drive.ready();
+                  this.drive.replicate(connection)
+                  await this.drive.ready()
+                  console.log('[RelayManager] Drive replication started with peer writer', writerKey || peerKey.substring(0, 16))
                 }
 
                 console.log('Writer key added successfully');
@@ -304,12 +299,11 @@ export class RelayManager {
                   this.driveKey,
                   this.driveDiscoveryKey
                 );
-                await this.drive.ready();
               }
 
               if (this.drive) {
-                await this.drive.ready();
                 this.drive.replicate(connection);
+                await this.drive.ready();
                 console.log('[RelayManager] Drive replication started with peer writer', writerKey || peerKey.substring(0, 16));
               }
             }
@@ -330,9 +324,9 @@ export class RelayManager {
         console.log('[RelayManager] Replicating Autobase with peer');
         this.relay.replicate(connection);
         if (this.drive) {
-          await this.drive.ready();
           console.log('[RelayManager] Replicating Hyperdrive with peer');
           this.drive.replicate(connection);
+          await this.drive.ready();
           console.log('[RelayManager] Hyperdrive replication stream established with peer', peerKey.substring(0, 16));
         }
       });

--- a/hypertuna-worker/test/drive-replication.test.js
+++ b/hypertuna-worker/test/drive-replication.test.js
@@ -20,7 +20,7 @@ class TestRelayManager extends RelayManager {
   }
 }
 
-test('drive replicates after ready on peer connection', async t => {
+test('drive replicates before ready on peer connection', async t => {
   const manager = new TestRelayManager()
   manager.initializeFake()
 
@@ -29,10 +29,10 @@ test('drive replicates after ready on peer connection', async t => {
 
   manager.drive.ready = async () => {
     readyCalled = true
+    t.ok(replicateCalled, 'replicate called before drive.ready')
   }
   manager.drive.replicate = () => {
     replicateCalled = true
-    t.ok(readyCalled, 'drive.ready called before replicate')
   }
 
   const handler = manager.swarm.listeners('connection')[0]


### PR DESCRIPTION
## Summary
- update README about relay hyperdrive initialization
- defer drive.ready until after replication
- replicate drive before awaiting ready in connection handler

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688419e24ccc832aa2d3e95b7a6389f6