### PR TITLE
Add file hashing for uploads

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -138,12 +138,15 @@ class NostrEvents {
         }
 
         let fileId = null;
+        let fileDataHash = null;
         let finalContent = content;
         if (filePath) {
-            const baseId = NostrUtils.generateRandomId();
+            const { promises: fs } = await import('fs');
+            const fileBuffer = await fs.readFile(filePath);
+            fileDataHash = await NostrUtils.computeSha256(fileBuffer);
             const extPart = filePath.split('.').pop();
             const ext = extPart && extPart !== filePath ? `.${extPart}` : '';
-            fileId = `${baseId}${ext}`;
+            fileId = `${fileDataHash}${ext}`;
 
             let gatewayDomain;
             try {
@@ -171,7 +174,7 @@ class NostrEvents {
             privateKey
         );
 
-        return { event, fileId };
+        return { event, fileId, fileDataHash };
     }
     
     /**

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2617,7 +2617,7 @@ async fetchMultipleProfiles(pubkeys) {
         );
         
         // Create message event
-        const { event, fileId } = await NostrEvents.createGroupMessage(
+        const { event, fileId, fileDataHash } = await NostrEvents.createGroupMessage(
             groupId,
             content,
             previousRefs,
@@ -2638,7 +2638,7 @@ async fetchMultipleProfiles(pubkeys) {
             const relayKey = this.publicToInternalMap.get(groupId) || null;
             const msg = {
                 type: 'upload-file',
-                data: { relayKey, filePath, fileId }
+                data: { relayKey, filePath, fileId, fileHash: fileDataHash }
             };
             try {
                 window.workerPipe.write(JSON.stringify(msg) + '\n');

--- a/hypertuna-desktop/NostrUtils.js
+++ b/hypertuna-desktop/NostrUtils.js
@@ -265,6 +265,32 @@ export class NostrUtils {
     }
 
     /**
+     * Compute SHA-256 hash of data
+     * @param {Uint8Array|ArrayBuffer|string} data - Data to hash
+     * @returns {Promise<string>} - Hex encoded hash
+     */
+    static async computeSha256(data) {
+        const secp = nobleSecp256k1 || window.nobleSecp256k1;
+        if (!secp) {
+            throw new Error('Noble Secp256k1 library not available');
+        }
+
+        let bytes;
+        if (data instanceof Uint8Array) {
+            bytes = data;
+        } else if (data instanceof ArrayBuffer) {
+            bytes = new Uint8Array(data);
+        } else if (typeof data === 'string') {
+            bytes = new TextEncoder().encode(data);
+        } else {
+            throw new Error('Unsupported data type for hashing');
+        }
+
+        const hash = await secp.utils.sha256(bytes);
+        return this.bytesToHex(hash);
+    }
+
+    /**
      * Extract all HTTP/HTTPS URLs from a string
      * @param {string} text - Text to search
      * @returns {Array<string>} - Array of URLs


### PR DESCRIPTION
## Summary
- compute file hashes in `NostrUtils`
- use the hash as the identifier when creating text notes
- include the hash when notifying the worker about uploads

## Testing
- `npm test --prefix hypertuna-desktop` *(fails: brittle not found)*
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68866e3a17e0832ab61eebc69630c653