### PR TITLE
Update blob upload and fetch logic

### DIFF
--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -1597,7 +1597,7 @@ protocol.handle('/authorize', async (request) => {
 
       const { activeRelays } = await import('./hypertuna-relay-manager-adapter.mjs');
       const relayManager = activeRelays.get(relayKey);
-      if (!relayManager || !relayManager.relay || !relayManager.relay.blobs) {
+      if (!relayManager || !relayManager.relay) {
         updateMetrics(false);
         return {
           statusCode: 404,
@@ -1605,8 +1605,9 @@ protocol.handle('/authorize', async (request) => {
           body: b4a.from(JSON.stringify({ error: 'File not found' }))
         };
       }
-      console.log(`[RelayServer] Fetching file ${fileId} from blobs`);
-      const data = await relayManager.relay.blobs.get(fileId);
+      const hash = fileId.replace(/\..*$/, '');
+      console.log(`[RelayServer] Fetching blob ${hash} via metadata`);
+      const data = await relayManager.relay.getBlob(hash);
       if (!data) {
         updateMetrics(false);
         return {
@@ -1616,7 +1617,7 @@ protocol.handle('/authorize', async (request) => {
         };
       }
 
-      console.log(`[RelayServer] Retrieved file ${fileId} (${data.length} bytes)`);
+      console.log(`[RelayServer] Retrieved blob ${hash} (${data.length} bytes)`);
 
       updateMetrics(true);
       return {


### PR DESCRIPTION
## Summary
- switch file uploads in worker to use relay.putBlob
- retrieve drive files via Hyperbee metadata

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68866ff21f28832a886de30ca416119e