### PR TITLE
Fix blob deduplication

### DIFF
--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -770,7 +770,11 @@ async handleSubscription(connectionKey) {
   async putBlob(data) {
     const hashBytes = await nobleSecp256k1.utils.sha256(b4a.from(data))
     const hash = NostrUtils.bytesToHex(hashBytes)
-    await this.append({ type: 'blob-store', hash, blob: data })
+    const key = b4a.from(`blob:hash:${hash}`, 'utf8')
+    const existing = await this.view.bee.get(key)
+    if (!existing) {
+      await this.append({ type: 'blob-store', hash, blob: data })
+    }
     return hash
   }
 

--- a/hypertuna-worker/test/blob-storage.test.js
+++ b/hypertuna-worker/test/blob-storage.test.js
@@ -1,0 +1,25 @@
+import test from 'brittle'
+import NostrRelay from '../hypertuna-relay-event-processor.mjs'
+
+// Ensure calling putBlob twice with the same data only stores one entry
+
+export default test('putBlob avoids duplicate uploads', async t => {
+  const relay = new NostrRelay(null, null, { verifyEvent: async () => true })
+  const data = 'hello world'
+
+  // first upload
+  const hash1 = await relay.putBlob(data)
+
+  // track additional append calls
+  let appendCount = 0
+  const origAppend = relay.append.bind(relay)
+  relay.append = async op => {
+    appendCount++
+    return origAppend(op)
+  }
+
+  const hash2 = await relay.putBlob(data)
+
+  t.is(hash1, hash2)
+  t.is(appendCount, 0)
+})


### PR DESCRIPTION
## Summary
- avoid duplicate writes for blobs
- test deduplication logic

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886752301f0832aa4254f5d6d7693af