### PR TITLE
Fix hyperblobs core reference

### DIFF
--- a/hypertuna-worker/hypertuna-relay-helper.mjs
+++ b/hypertuna-worker/hypertuna-relay-helper.mjs
@@ -29,7 +29,11 @@ export default class Autobee extends Autobase {
       })
       console.log('[Autobee] Created Hyperbee instance');
       
-      const blobs = new Hyperblobs(viewStore.get('relay-blobs'))
+      const blobSession = viewStore.get('relay-blobs')
+      const blobCore = blobSession && typeof blobSession.getBackingCore === 'function'
+        ? blobSession.getBackingCore()
+        : (blobSession?.core || blobSession)
+      const blobs = new Hyperblobs(blobCore)
       console.log('[Autobee] Created Hyperblobs instance');
       
       // Monitor bee and blobs readiness


### PR DESCRIPTION
## Summary
- use backing hypercore when creating hyperblobs

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1ed9600832a9a9ab4ae9b241692