### PR TITLE
Fix Hyperblobs initialization

### DIFF
--- a/hypertuna-worker/hypertuna-relay-helper.mjs
+++ b/hypertuna-worker/hypertuna-relay-helper.mjs
@@ -30,10 +30,10 @@ export default class Autobee extends Autobase {
       console.log('[Autobee] Created Hyperbee instance');
       
       const blobSession = viewStore.get('relay-blobs')
-      const blobCore = blobSession && typeof blobSession.getBackingCore === 'function'
-        ? blobSession.getBackingCore()
-        : (blobSession?.core || blobSession)
-      const blobs = new Hyperblobs(blobCore)
+      const blobs = new Hyperblobs(blobSession)
+      if (typeof blobSession?.ready === 'function') {
+        blobs.ready = blobSession.ready.bind(blobSession)
+      }
       console.log('[Autobee] Created Hyperblobs instance');
       
       // Monitor bee and blobs readiness


### PR DESCRIPTION
## Summary
- revert blob session handling in Autobee
- ensure Hyperblobs.ready uses session readiness

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886db4da348832aa0018d028fb073c8