### PR TITLE
Await hypercore view initialization

### DIFF
--- a/hypertuna-worker/hypertuna-relay-helper.mjs
+++ b/hypertuna-worker/hypertuna-relay-helper.mjs
@@ -17,7 +17,7 @@ export default class Autobee extends Autobase {
       bootstrap = null
     }
 
-    const open = (viewStore) => {
+    const open = async (viewStore) => {
       console.log('[Autobee] Opening view store...');
       
       const core = viewStore.get('autobee')
@@ -35,23 +35,24 @@ export default class Autobee extends Autobase {
         blobs.ready = blobSession.ready.bind(blobSession)
       }
       console.log('[Autobee] Created Hyperblobs instance');
-      
-      // Monitor bee and blobs readiness
-      bee.ready().then(() => {
-        console.log('[Autobee] Hyperbee is ready');
-        console.log('[Autobee] - Version:', bee.version);
-        console.log('[Autobee] - Feed length:', bee.feed?.length || 0);
-      }).catch(err => {
-        console.error('[Autobee] Hyperbee ready error:', err);
-      });
-      
-      blobs.ready().then(() => {
-        console.log('[Autobee] Hyperblobs is ready');
-        console.log('[Autobee] - Core length:', blobs.core?.length || 0);
-      }).catch(err => {
-        console.error('[Autobee] Hyperblobs ready error:', err);
-      });
-      
+
+      try {
+        await bee.ready()
+        console.log('[Autobee] Hyperbee is ready')
+        console.log('[Autobee] - Version:', bee.version)
+        console.log('[Autobee] - Feed length:', bee.feed?.length || 0)
+      } catch (err) {
+        console.error('[Autobee] Hyperbee ready error:', err)
+      }
+
+      try {
+        await blobs.ready()
+        console.log('[Autobee] Hyperblobs is ready')
+        console.log('[Autobee] - Core length:', blobs.core?.length || 0)
+      } catch (err) {
+        console.error('[Autobee] Hyperblobs ready error:', err)
+      }
+
       return { bee, blobs }
     }
 

--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -132,6 +132,9 @@ export class RelayManager {
         valueEncoding: c.any,
         verifyEvent: this.verifyEvent.bind(this)
       });
+
+      // Wait for the relay to finish opening its view
+      await this.relay.ready();
   
       // Monitor relay events
       this.relay.on('error', (err) => {

--- a/hypertuna-worker/test/blob-storage.test.js
+++ b/hypertuna-worker/test/blob-storage.test.js
@@ -6,6 +6,7 @@ import b4a from 'b4a'
 
 export default test('putBlob avoids duplicate uploads', async t => {
   const relay = new NostrRelay(null, null, { verifyEvent: async () => true })
+  await relay.ready()
   const data = b4a.from('hello world')
 
   const metadata = { uploadedBy: 'tester' }

--- a/hypertuna-worker/test/query-union.test.js
+++ b/hypertuna-worker/test/query-union.test.js
@@ -3,8 +3,9 @@ import NostrRelay from '../hypertuna-relay-event-processor.mjs'
 
 // Basic unit test for the two-level union/intersection logic used when applying filters
 
-test('filter union across same attribute values', t => {
+test('filter union across same attribute values', async t => {
   const relay = new NostrRelay(null, null, { verifyEvent: async () => true })
+  await relay.ready()
 
   // Simulate query results
   const kindUnion = new Set(['id1']) // results for kinds 9000/9001 (9001 has no events)


### PR DESCRIPTION
## Summary
- make `open` in `Autobee` async and await hyperbee/blobs
- wait for relay readiness inside `RelayManager`
- update tests to await `relay.ready()`

## Testing
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886fe566b8c832aa7bb16ce663135cf