### PR TITLE
Clarify relay replication

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -335,6 +335,12 @@ export class RelayManager {
         try {
           replicationStream = this.relay.replicate(connection);
           console.log('[RelayManager] relay.replicate() called successfully');
+          // this.relay.replicate(connection) replicates both Corestore and
+          // Hyperblobs in a single stream. See the Corestore guide
+          // documentation (autobase-hyperblobs-documentation/corestore-guide.md
+          // lines 45-50) and the Autobase guide API section
+          // (autobase-hyperblobs-documentation/autobase-guide-api.md
+          // lines 211-221).
         } catch (replError) {
           console.error('[RelayManager] Failed to create replication stream:', replError);
           console.error('[RelayManager] Stack:', replError.stack);


### PR DESCRIPTION
## Summary
- note that relay.replicate() syncs Corestore and Hyperblobs together
- reference documentation for the replication approach

## Testing
- `npm test --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cb01346c832ab6b051f75602a2c9