### PR TITLE
Fix async initialization logging

### DIFF
--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -186,9 +186,13 @@ export default class NostrRelay extends Autobee {
     this.findCommonIds = this.findCommonIds.bind(this);
     
     console.log('[NostrRelay] Constructor completed');
-    console.log('[NostrRelay] Initial state:');
-    console.log('[NostrRelay] - Writable:', this.writable);
-    console.log('[NostrRelay] - Has view:', !!this.view);
+    this.ready().then(() => {
+      console.log('[NostrRelay] Initial state:');
+      console.log('[NostrRelay] - Writable:', this.writable);
+      console.log('[NostrRelay] - Has view:', !!this.view);
+    }).catch(err => {
+      console.error('[NostrRelay] Ready error:', err);
+    });
   }
   
   // Update defaultVerifyEvent to be async

--- a/hypertuna-worker/hypertuna-relay-helper.mjs
+++ b/hypertuna-worker/hypertuna-relay-helper.mjs
@@ -60,12 +60,16 @@ export default class Autobee extends Autobase {
       console.log('[Autobee] Calling parent Autobase constructor...');
       super(store, bootstrap, { ...handlers, open, apply });
       console.log('[Autobee] Parent constructor completed');
-      
-      // Log initial state
-      console.log('[Autobee] Initial state:');
-      console.log('[Autobee] - Key:', this.key ? b4a.toString(this.key, 'hex') : 'not set');
-      console.log('[Autobee] - Writable:', this.writable);
-      console.log('[Autobee] - Has view:', !!this.view);
+
+      // Defer initial state logging until the Autobase is ready
+      this.ready().then(() => {
+        console.log('[Autobee] Initial state:');
+        console.log('[Autobee] - Key:', this.key ? b4a.toString(this.key, 'hex') : 'not set');
+        console.log('[Autobee] - Writable:', this.writable);
+        console.log('[Autobee] - Has view:', !!this.view);
+      }).catch(err => {
+        console.error('[Autobee] Ready error:', err);
+      });
       
       // Monitor state changes
       this.on('update', () => {


### PR DESCRIPTION
## Summary
- prevent Autobee constructor from reading key before ready
- defer NostrRelay initial state logs until ready resolves

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c52ea9f4832a91a2cbb3a188b7eb