### PR TITLE
Support fileSharing option when creating groups

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2321,6 +2321,7 @@ async fetchMultipleProfiles(pubkeys) {
      * @param {boolean} groupData.isPublic - Whether the group is public
      * @param {boolean} groupData.isOpen - Whether the group is open to join
      * @param {string} [groupData.authenticatedRelayUrl] - Tokenized relay URL returned by the worker
+     * @param {boolean} [groupData.fileSharing] - Whether file sharing is enabled
      * @returns {Promise<Object>} - Collection of created events
      */
     async createGroup(groupData) {
@@ -2342,7 +2343,8 @@ async fetchMultipleProfiles(pubkeys) {
             isOpen: Boolean(groupData.isOpen),
             identifier: groupData.identifier || null,
             proxyServer: groupData.proxyServer || '',
-            authenticatedRelayUrl: groupData.authenticatedRelayUrl || null
+            authenticatedRelayUrl: groupData.authenticatedRelayUrl || null,
+            fileSharing: Boolean(groupData.fileSharing)
         };
         
         console.log('Creating group with normalized data:', normalizedData);
@@ -2473,6 +2475,9 @@ async fetchMultipleProfiles(pubkeys) {
      * Join a group with authentication flow
      * @param {string} groupId - Group ID
      * @param {string} inviteCode - Optional invite code for closed groups
+     * @param {Object} [options] - Additional join options
+     * @param {boolean} [options.publish] - Whether to publish the join request
+     * @param {boolean} [options.fileSharing] - Enable file sharing for this join
      * @returns {Promise<Object>} - Join request event
      */
     async joinGroup(publicIdentifier, inviteCode = null, options = {}) {

--- a/hypertuna-desktop/NostrIntegration.js
+++ b/hypertuna-desktop/NostrIntegration.js
@@ -434,7 +434,7 @@ class NostrIntegration {
      * @param {string} [authenticatedRelayUrl] - Tokenized relay URL from the worker
      * @returns {Promise<Object>} - Create group events collection
      */
-    async createGroup(name, about, isPublic, isOpen, relayKey, proxyServer, npub, authenticatedRelayUrl = null) {
+    async createGroup(name, about, isPublic, isOpen, relayKey, proxyServer, npub, authenticatedRelayUrl = null, fileSharing = false) {
         try {
             // Validate inputs
             if (typeof name !== 'string') {
@@ -450,7 +450,7 @@ class NostrIntegration {
                 throw new Error('isOpen must be a boolean');
             }
             
-            console.log("NostrIntegration creating group:", { name, about, isPublic, isOpen, npub, authenticatedRelayUrl });
+            console.log("NostrIntegration creating group:", { name, about, isPublic, isOpen, npub, authenticatedRelayUrl, fileSharing });
         
             const eventsCollection = await this.client.createGroup({
                 name,
@@ -460,7 +460,8 @@ class NostrIntegration {
                 relayKey,
                 proxyServer,
                 npub,
-                authenticatedRelayUrl
+                authenticatedRelayUrl,
+                fileSharing
             });
             
             console.log('Group created successfully with the following events:');

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -823,7 +823,7 @@ async function createRelay() {
 }
 
 // Create a relay instance with provided parameters and return relay key
-async function createRelayInstance(name, description, isPublic, isOpen) {
+async function createRelayInstance(name, description, isPublic, isOpen, fileSharing = false) {
   return new Promise((resolve, reject) => {
     if (!workerPipe) {
       addLog('Worker not running', 'error')
@@ -839,13 +839,13 @@ async function createRelayInstance(name, description, isPublic, isOpen) {
 
     workerPipe.write(JSON.stringify({
       type: 'create-relay',
-      data: { name, description, isPublic, isOpen }
+      data: { name, description, isPublic, isOpen, fileSharing }
     }) + '\n')
   })
 }
 
 // Join a relay instance via the worker-driven authentication flow
-async function joinRelayInstance(publicIdentifier) {
+async function joinRelayInstance(publicIdentifier, fileSharing = false) {
   return new Promise((resolve, reject) => {
     if (!workerPipe) {
       addLog('Worker not running', 'error');
@@ -863,10 +863,12 @@ async function joinRelayInstance(publicIdentifier) {
     addLog(`Starting join flow for relay: ${publicIdentifier}`, 'status');
     
     // Send message to worker to start the process
-    workerPipe.write(JSON.stringify({
-      type: 'start-join-flow',
-      data: { publicIdentifier }
-    }) + '\n');
+    workerPipe.write(
+      JSON.stringify({
+        type: 'start-join-flow',
+        data: { publicIdentifier, fileSharing }
+      }) + '\n'
+    );
   });
 }
 

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -2078,7 +2078,7 @@ async function createGroupJoinRequest(publicIdentifier, privateKey) {
 }
 
 export async function startJoinAuthentication(options) {
-  const { publicIdentifier } = options;
+  const { publicIdentifier, fileSharing = false } = options;
   const userNsec = config.nostr_nsec_hex;
   const userPubkey = NostrUtils.getPublicKey(userNsec);
   if (config.nostr_pubkey_hex && userPubkey !== config.nostr_pubkey_hex) {
@@ -2087,6 +2087,7 @@ export async function startJoinAuthentication(options) {
 
   console.log(`[RelayServer] Starting join authentication for: ${publicIdentifier}`);
   console.log(`[RelayServer] Using user pubkey: ${userPubkey.substring(0, 8)}...`);
+  console.log(`[RelayServer] File sharing enabled: ${fileSharing}`);
 
   if (!publicIdentifier || !userPubkey || !userNsec) {
     const errorMsg = 'Missing publicIdentifier or user credentials for join flow.';

--- a/hypertuna-worker/relay-manager-hyperbee-only/pear-relay-server.mjs
+++ b/hypertuna-worker/relay-manager-hyperbee-only/pear-relay-server.mjs
@@ -1993,7 +1993,7 @@ async function createGroupJoinRequest(publicIdentifier, privateKey) {
 }
 
 export async function startJoinAuthentication(options) {
-  const { publicIdentifier } = options;
+  const { publicIdentifier, fileSharing = false } = options;
   const userNsec = config.nostr_nsec_hex;
   const userPubkey = NostrUtils.getPublicKey(userNsec);
   if (config.nostr_pubkey_hex && userPubkey !== config.nostr_pubkey_hex) {
@@ -2002,6 +2002,7 @@ export async function startJoinAuthentication(options) {
 
   console.log(`[RelayServer] Starting join authentication for: ${publicIdentifier}`);
   console.log(`[RelayServer] Using user pubkey: ${userPubkey.substring(0, 8)}...`);
+  console.log(`[RelayServer] File sharing enabled: ${fileSharing}`);
 
   if (!publicIdentifier || !userPubkey || !userNsec) {
     const errorMsg = 'Missing publicIdentifier or user credentials for join flow.';


### PR DESCRIPTION
## Summary
- include `fileSharing` checkbox state when creating a group
- pass `fileSharing` when requesting a new relay instance
- send `fileSharing` in create-relay worker payload
- forward `fileSharing` for join flows and worker authentication

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68884374897c832a8b6f7ce95597224b