### PR TITLE
Add file sharing flag to group metadata

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -638,9 +638,17 @@ class NostrEvents {
         // Extract hypertunaId and check for identifier tag
         const hypertunaId = this._getTagValue(event, 'hypertuna');
         const hasIdentifierTag = event.tags.some(tag => tag[0] === 'i' && tag[1] === 'hypertuna:relay');
-        
+
+        // Determine file sharing status from tags
+        let fileSharing = false;
+        if (this._hasTag(event, 'file-sharing-on')) {
+            fileSharing = true;
+        } else if (this._hasTag(event, 'file-sharing-off')) {
+            fileSharing = false;
+        }
+
         console.log(`Parsing group metadata: id=${groupId}, hypertunaId=${hypertunaId}, hasIdentifierTag=${hasIdentifierTag}`);
-        
+
         return {
             id: groupId,
             name: this._getTagValue(event, 'name') || 'Unnamed Group',
@@ -651,7 +659,8 @@ class NostrEvents {
             relay: event.pubkey,
             event: event,
             hypertunaId: hypertunaId,
-            isHypertunaRelay: hasIdentifierTag
+            isHypertunaRelay: hasIdentifierTag,
+            fileSharing
         };
     }
     

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1547,7 +1547,7 @@ async fetchMultipleProfiles(pubkeys) {
             return;
         }
         
-        // Update group data
+        // Update group data including file sharing flag
         this.groups.set(publicIdentifier, groupData);
         
         // Store hypertuna mapping if available

--- a/hypertuna-desktop/test/nostr-events.test.js
+++ b/hypertuna-desktop/test/nostr-events.test.js
@@ -15,3 +15,30 @@ test('group message content URLs generate r tags', async t => {
   const hasTag = event.tags.some(tag => tag[0] === 'r' && tag[1] === 'https://example.com/page')
   t.ok(hasTag)
 })
+
+test('parseGroupMetadata detects file sharing tags', async t => {
+  global.window = {}
+  const { default: NostrEvents } = await import('../NostrEvents.js')
+  const eventOn = {
+    kind: NostrEvents.KIND_GROUP_METADATA,
+    created_at: 0,
+    tags: [
+      ['d', 'group1'],
+      ['file-sharing-on']
+    ]
+  }
+  const eventOff = {
+    kind: NostrEvents.KIND_GROUP_METADATA,
+    created_at: 0,
+    tags: [
+      ['d', 'group2'],
+      ['file-sharing-off']
+    ]
+  }
+
+  const groupOn = NostrEvents.parseGroupMetadata(eventOn)
+  const groupOff = NostrEvents.parseGroupMetadata(eventOff)
+
+  t.ok(groupOn.fileSharing)
+  t.absent(groupOff.fileSharing)
+})


### PR DESCRIPTION
## Summary
- detect file sharing tags when parsing group metadata
- store the `fileSharing` property with group metadata
- test detection of `file-sharing-on` and `file-sharing-off`

## Testing
- `npm test` *(fails: brittle not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6888486316a0832a9bf50a8722b83384