### PR TITLE
Add fileSharing persistence on group creation

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -2446,6 +2446,14 @@ async fetchMultipleProfiles(pubkeys) {
             // Continue even if this fails
         }
         
+        // Immediately store the group metadata locally
+        const parsedGroup = NostrEvents.parseGroupMetadata(metadataEvent);
+        if (parsedGroup) {
+            this.groups.set(groupId, parsedGroup);
+            this.hypertunaGroups.set(hypertunaId, groupId);
+            this.groupHypertunaIds.set(groupId, hypertunaId);
+        }
+
         // Subscribe to this group
         this.subscribeToGroup(groupId);
 


### PR DESCRIPTION
## Summary
- capture the `fileSharing` flag when a group is created
- store parsed metadata immediately so the flag is present in the groups map

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in worker *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688849bc74e8832a9704d272158c9fe1