### PR TITLE
Support file sharing flag in relay server

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -678,6 +678,7 @@ export async function autoConnectStoredRelays(config) {
                     name: profile.name,
                     description: profile.description,
                     storageDir: profile.relay_storage,
+                    fileSharing: profile.fileSharing || false,
                     config,
                     fromAutoConnect: true  // Add this flag
                 });

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -590,9 +590,9 @@ function setupProtocolHandlers(protocol) {
   protocol.handle('/relay/create', async (request) => {
     console.log('[RelayServer] Create relay requested');
     const body = JSON.parse(request.body.toString());
-    const { name, description, isPublic = false, isOpen = false } = body;
-    
-    console.log('[RelayServer] Creating relay:', { name, description });
+    const { name, description, isPublic = false, isOpen = false, fileSharing = false } = body;
+
+    console.log('[RelayServer] Creating relay:', { name, description, isPublic, isOpen, fileSharing });
     
     if (!name) {
       updateMetrics(false);
@@ -674,9 +674,9 @@ function setupProtocolHandlers(protocol) {
   protocol.handle('/relay/join', async (request) => {
     console.log('[RelayServer] Join relay requested');
     const body = JSON.parse(request.body.toString());
-    const { relayKey, name, description } = body;
-    
-    console.log('[RelayServer] Joining relay:', { relayKey, name, description });
+    const { relayKey, name, description, fileSharing = false } = body;
+
+    console.log('[RelayServer] Joining relay:', { relayKey, name, description, fileSharing });
     
     if (!relayKey) {
       updateMetrics(false);
@@ -692,6 +692,7 @@ function setupProtocolHandlers(protocol) {
         relayKey,
         name,
         description,
+        fileSharing,
         config
       });
       
@@ -2035,7 +2036,7 @@ export async function createRelay(options) {
 
 export async function joinRelay(options) {
   const { fileSharing = false } = options;
-  console.log('[RelayServer] Joining relay via adapter:', options);
+  console.log('[RelayServer] Joining relay via adapter:', { ...options, fileSharing });
   const result = await joinRelayManager({
     ...options,
     fileSharing,


### PR DESCRIPTION
## Summary
- allow clients to specify `fileSharing` when creating or joining a relay
- forward the flag through relay initialization
- include the file-sharing profile flag when auto connecting stored relays

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688855de8f78832a965be7e4a7b0ca6c