### PR TITLE
Pass fileSharing flag to worker

### DIFF
--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -807,9 +807,10 @@ async function createRelay() {
     
     // Send create relay command to worker
     if (workerPipe) {
+      const fileSharing = newGroupFileSharing ? newGroupFileSharing.checked : false
       workerPipe.write(JSON.stringify({
         type: 'create-relay',
-        data: { name, description }
+        data: { name, description, fileSharing }
       }) + '\n')
     }
     
@@ -873,7 +874,7 @@ async function joinRelayInstance(publicIdentifier, fileSharing = false) {
 }
 
 // Join a relay using data from an invite event
-async function joinRelayFromInvite(relayKey, name = '', description = '', publicIdentifier = '', authToken = '') {
+async function joinRelayFromInvite(relayKey, name = '', description = '', publicIdentifier = '', authToken = '', fileSharing = false) {
   return new Promise((resolve, reject) => {
     if (!workerPipe) {
       addLog('Worker not running', 'error');
@@ -884,7 +885,7 @@ async function joinRelayFromInvite(relayKey, name = '', description = '', public
       workerPipe.write(
         JSON.stringify({
           type: 'join-relay',
-          data: { relayKey, name, description, publicIdentifier, authToken }
+          data: { relayKey, name, description, publicIdentifier, authToken, fileSharing }
         }) + '\n'
       );
       resolve();
@@ -926,9 +927,10 @@ async function joinRelay() {
     
     // Send join relay command to worker
     if (workerPipe) {
+      const fileSharing = false
       workerPipe.write(JSON.stringify({
         type: 'join-relay',
-        data: { relayKey, name, description }
+        data: { relayKey, name, description, fileSharing }
       }) + '\n')
     }
     

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -250,7 +250,8 @@ if (workerPipe) {
               if (relayServer) {
                 try {
                   // Call the relay server's create relay function
-                  const result = await relayServer.createRelay(message.data);
+                  const { fileSharing = false, ...options } = message.data || {};
+                  const result = await relayServer.createRelay({ ...options, fileSharing });
                   relayMembers.set(result.relayKey, result.profile?.members || [])
                   await applyPendingAuthUpdates(updateRelayAuthToken, result.relayKey, result.profile?.public_identifier);
 
@@ -288,7 +289,8 @@ if (workerPipe) {
               if (relayServer) {
                 try {
                   // Call the relay server's join relay function
-                  const result = await relayServer.joinRelay(message.data)
+                  const { fileSharing: joinFileSharing = false, ...joinOpts } = message.data || {};
+                  const result = await relayServer.joinRelay({ ...joinOpts, fileSharing: joinFileSharing })
                   relayMembers.set(result.relayKey, result.profile?.members || [])
                   await applyPendingAuthUpdates(updateRelayAuthToken, result.relayKey, result.profile?.public_identifier);
 

--- a/hypertuna-worker/relay-manager-hyperbee-only/index.js
+++ b/hypertuna-worker/relay-manager-hyperbee-only/index.js
@@ -250,7 +250,8 @@ if (workerPipe) {
               if (relayServer) {
                 try {
                   // Call the relay server's create relay function
-                  const result = await relayServer.createRelay(message.data);
+                  const { fileSharing = false, ...options } = message.data || {};
+                  const result = await relayServer.createRelay({ ...options, fileSharing });
                   relayMembers.set(result.relayKey, result.profile?.members || [])
                   await applyPendingAuthUpdates(updateRelayAuthToken, result.relayKey, result.profile?.public_identifier);
 
@@ -288,7 +289,8 @@ if (workerPipe) {
               if (relayServer) {
                 try {
                   // Call the relay server's join relay function
-                  const result = await relayServer.joinRelay(message.data)
+                  const { fileSharing: joinFileSharing = false, ...joinOpts } = message.data || {};
+                  const result = await relayServer.joinRelay({ ...joinOpts, fileSharing: joinFileSharing })
                   relayMembers.set(result.relayKey, result.profile?.members || [])
                   await applyPendingAuthUpdates(updateRelayAuthToken, result.relayKey, result.profile?.public_identifier);
 


### PR DESCRIPTION
## Summary
- send fileSharing when creating or joining relays from the desktop
- update worker index files to forward fileSharing to relayServer

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688857bc5bc0832ab803a494a8b35db9