### PR TITLE
Add fileSharing flag to relay metadata

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -542,6 +542,7 @@ export async function autoConnectStoredRelays(config) {
         
         // Process each relay profile
         for (const profile of relayProfiles) {
+            const fileSharing = profile.fileSharing;
             try {
                 // Skip if already active or auto-connect disabled
                 if (activeRelays.has(profile.relay_key)) {
@@ -678,7 +679,7 @@ export async function autoConnectStoredRelays(config) {
                     name: profile.name,
                     description: profile.description,
                     storageDir: profile.relay_storage,
-                    fileSharing: profile.fileSharing || false,
+                    fileSharing,
                     config,
                     fromAutoConnect: true  // Add this flag
                 });
@@ -913,6 +914,7 @@ export async function getActiveRelays() {
             peerCount,
             name: profile?.name || `Relay ${key.substring(0, 8)}`,
             description: profile?.description || '',
+            fileSharing: profile?.fileSharing || false,
             connectionUrl: `wss://${globalConfig?.proxy_server_address || 'localhost'}/${identifierPath}`,
             createdAt: profile?.created_at || profile?.joined_at || null,
             isActive: true

--- a/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-adapter.mjs
@@ -522,6 +522,7 @@ export async function autoConnectStoredRelays(config) {
         
         // Process each relay profile
         for (const profile of relayProfiles) {
+            const fileSharing = profile.fileSharing;
             try {
                 // Skip if already active or auto-connect disabled
                 if (activeRelays.has(profile.relay_key)) {
@@ -658,6 +659,7 @@ export async function autoConnectStoredRelays(config) {
                     name: profile.name,
                     description: profile.description,
                     storageDir: profile.relay_storage,
+                    fileSharing,
                     config,
                     fromAutoConnect: true  // Add this flag
                 });
@@ -882,6 +884,7 @@ export async function getActiveRelays() {
             peerCount,
             name: profile?.name || `Relay ${key.substring(0, 8)}`,
             description: profile?.description || '',
+            fileSharing: profile?.fileSharing || false,
             connectionUrl: `wss://${globalConfig?.proxy_server_address || 'localhost'}/${identifierPath}`,
             createdAt: profile?.created_at || profile?.joined_at || null,
             isActive: true


### PR DESCRIPTION
## Summary
- wire `fileSharing` flag through auto connect
- surface `fileSharing` in `getActiveRelays`

## Testing
- `npx brittle test/*.test.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/brittle)*

------
https://chatgpt.com/codex/tasks/task_e_68885a3608e8832a8d7f0a2736622ba5