### PR TITLE
Handle file-sharing flag in invites

### DIFF
--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -508,6 +508,12 @@ class NostrEvents {
             tags.push(['about', metadata.about]);
         }
 
+        if (metadata.fileSharing) {
+            tags.push(['file-sharing-on']);
+        } else {
+            tags.push(['file-sharing-off']);
+        }
+
         return this.createEvent(
             this.KIND_GROUP_INVITE_CREATE,
             'Creating invite code',

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1659,7 +1659,8 @@ async fetchMultipleProfiles(pubkeys) {
                 relayKey: data.relayKey,
                 isPublic: data.isPublic !== false,
                 name: NostrEvents._getTagValue(event, 'name') || '',
-                about: NostrEvents._getTagValue(event, 'about') || ''
+                about: NostrEvents._getTagValue(event, 'about') || '',
+                fileSharing: NostrEvents._hasTag(event, 'file-sharing-on')
             };
 
             this.invites.set(event.id, invite);
@@ -3035,6 +3036,11 @@ async fetchMultipleProfiles(pubkeys) {
             ['name', group.name || ''],
             ['about', group.about || '']
         ];
+        if (group.fileSharing) {
+            tags.push(['file-sharing-on']);
+        } else {
+            tags.push(['file-sharing-off']);
+        }
 
         const event = await NostrEvents.createEvent(
             NostrEvents.KIND_GROUP_INVITE_CREATE,
@@ -3115,6 +3121,11 @@ async fetchMultipleProfiles(pubkeys) {
                 ['name', group.name || ''],
                 ['about', group.about || '']
             ];
+            if (group.fileSharing) {
+                tags.push(['file-sharing-on']);
+            } else {
+                tags.push(['file-sharing-off']);
+            }
 
             const inviteEvent = await NostrEvents.createEvent(
                 NostrEvents.KIND_GROUP_INVITE_CREATE,

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -1417,7 +1417,7 @@
               try {
                   const invite = await this.nostr.client.acceptInvite(inviteId);
                   if (window.joinRelayFromInvite) {
-                      await window.joinRelayFromInvite(invite.relayKey, invite.name, invite.about, invite.publicIdentifier || invite.groupId, invite.token);
+                      await window.joinRelayFromInvite(invite.relayKey, invite.name, invite.about, invite.publicIdentifier || invite.groupId, invite.token, invite.fileSharing);
                   } else if (window.joinRelayInstance) {
                       await window.joinRelayInstance(invite.relayKey);
                   }

--- a/hypertuna-desktop/test/nostr-events.test.js
+++ b/hypertuna-desktop/test/nostr-events.test.js
@@ -42,3 +42,14 @@ test('parseGroupMetadata detects file sharing tags', async t => {
   t.ok(groupOn.fileSharing)
   t.absent(groupOff.fileSharing)
 })
+
+test('createGroupInviteEvent includes file sharing tag', async t => {
+  global.window = {}
+  const { default: NostrEvents } = await import('../NostrEvents.js')
+
+  const eventOn = await NostrEvents.createGroupInviteEvent('group1', privKey, { fileSharing: true })
+  const eventOff = await NostrEvents.createGroupInviteEvent('group2', privKey, { fileSharing: false })
+
+  t.ok(eventOn.tags.some(tag => tag[0] === 'file-sharing-on'))
+  t.ok(eventOff.tags.some(tag => tag[0] === 'file-sharing-off'))
+})

--- a/hypertuna-desktop/test/nostr-group-client.test.js
+++ b/hypertuna-desktop/test/nostr-group-client.test.js
@@ -1,5 +1,6 @@
 import test from 'brittle'
 import NostrGroupClient from '../NostrGroupClient.js'
+import { NostrUtils } from '../NostrUtils.js'
 
 class DummyRelayManager {
   constructor () {
@@ -31,4 +32,26 @@ test('store auth token from membership event and use in connection', async t => 
 
   await client.connectToGroupRelay('group1', 'wss://relay.example.com')
   t.is(client.relayManager.added[0].url, 'wss://relay.example.com?token=tok123')
+})
+
+test('process invite event records file sharing flag', async t => {
+  global.window = {}
+  const client = new NostrGroupClient(false)
+  client.user = { pubkey: 'bob', privateKey: '1'.repeat(64) }
+
+  const payload = { relayUrl: 'wss://relay.example.com', token: 'tok', relayKey: 'rk', isPublic: true }
+  const { default: NostrEvents } = await import('../NostrEvents.js')
+  const enc = NostrUtils.encrypt(client.user.privateKey, 'alice', JSON.stringify(payload))
+  const event = {
+    id: 'id1',
+    pubkey: 'alice',
+    kind: NostrEvents.KIND_GROUP_INVITE_CREATE,
+    created_at: 0,
+    content: enc,
+    tags: [ ['h', 'group1'], ['file-sharing-on'] ]
+  }
+
+  client._processInviteEvent(event)
+  const invite = client.invites.get('id1')
+  t.ok(invite.fileSharing)
 })


### PR DESCRIPTION
## Summary
- include file sharing tag when creating invite events
- preserve file sharing tag when generating invites from join requests
- parse file sharing status in received invites
- pass file sharing flag when joining a relay from an invite
- cover invite flag logic with tests

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888387fed48832a8dd07bab47261774