### PR TITLE
Remove subnet authorization code from gateway

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -519,7 +519,7 @@ class EnhancedHyperswarmPool {
   }
  }
  
- async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, subnetHash, authToken) {
+async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, authToken) {
   try {
     console.log(`[ForwardMessage] ========================================`);
     console.log(`[ForwardMessage] FORWARDING RELAY MESSAGE`);
@@ -527,7 +527,6 @@ class EnhancedHyperswarmPool {
     console.log(`[ForwardMessage] Connection: ${connectionKey}`);
     console.log(`[ForwardMessage] Peer: ${peerPublicKey.substring(0, 8)}...`);
     console.log(`[ForwardMessage] Has auth: ${!!authToken}`);
-    console.log(`[ForwardMessage] Subnet: ${subnetHash?.substring(0, 8)}...`);
     
     const connection = await connectionPool.getConnection(peerPublicKey);
     
@@ -535,9 +534,6 @@ class EnhancedHyperswarmPool {
     const headers = { 'content-type': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
     
     const response = await connection.sendRequest({
@@ -645,7 +641,7 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
   }
 }
  
- async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null, subnetHash = null) {
+async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null) {
   try {
     console.log(`[GetEvents] Checking for events - relay: ${relayKey}, connection: ${connectionKey}`);
     
@@ -654,9 +650,6 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
     const headers = { 'accept': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
 
     const response = await connection.sendRequest({


### PR DESCRIPTION
## Summary
- drop subnet hashing middleware and helpers
- eliminate x-subnet-hash headers and subnet tracking in websocket flows
- simplify join flow by removing subnet data and authorization endpoints
- clean up leftover comments

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887d6d8858832a9d9fbcfc751dd90f