### PR TITLE
Remove subnet hash references from gateway client

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -572,7 +572,6 @@ async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message
     console.log(`[ForwardJoin] Relay: ${identifier}`);
     console.log(`[ForwardJoin] Peer: ${peer.publicKey.substring(0, 8)}...`);
     console.log(`[ForwardJoin] Has event: ${!!requestData.event}`);
-    console.log(`[ForwardJoin] Subnet hash: ${requestData.requesterSubnetHash?.substring(0, 8)}...`);
     
     const connection = await connectionPool.getConnection(peer.publicKey);
     


### PR DESCRIPTION
## Summary
- drop subnet hash logging from the join request forwarding helper

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887fccf71c832ab2c40215809c9237