### PR TITLE
Remove subnets from relay auth

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -190,9 +190,9 @@ export async function createRelay(options = {}) {
             const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
             const authStore = getRelayAuthStore();
             
-            authStore.addAuth(relayKey, config.nostr_pubkey_hex, authToken, '');
+            authStore.addAuth(relayKey, config.nostr_pubkey_hex, authToken);
             if (publicIdentifier) {
-                authStore.addAuth(publicIdentifier, config.nostr_pubkey_hex, authToken, '');
+                authStore.addAuth(publicIdentifier, config.nostr_pubkey_hex, authToken);
             }
             
             console.log('[RelayAdapter] Added auth token to auth store');
@@ -560,7 +560,6 @@ export async function autoConnectStoredRelays(config) {
                         authorizedUsers.forEach(user => {
                             authData[user.pubkey] = {
                                 token: user.token,
-                                allowedSubnets: user.subnets || [],
                                 createdAt: Date.now(),
                                 lastUsed: Date.now()
                             };
@@ -641,7 +640,6 @@ export async function autoConnectStoredRelays(config) {
                     authorizedUsers.forEach(user => {
                         authData[user.pubkey] = {
                             token: user.token,
-                            allowedSubnets: user.subnets || [],
                             createdAt: Date.now(),
                             lastUsed: Date.now()
                         };

--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -182,16 +182,9 @@ export async function updateRelayAuthToken(identifier, pubkey, token, newSubnetH
             try {
                 const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
                 const store = getRelayAuthStore();
-                const firstSubnet = newSubnetHashes[0] || '';
-                store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
+                store.addAuth(profile.relay_key, pubkey, token);
                 if (profile.public_identifier) {
-                    store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
-                }
-                for (const sub of newSubnetHashes.slice(1)) {
-                    store.addSubnet(profile.relay_key, pubkey, sub);
-                    if (profile.public_identifier) {
-                        store.addSubnet(profile.public_identifier, pubkey, sub);
-                    }
+                    store.addAuth(profile.public_identifier, pubkey, token);
                 }
             } catch (err) {
                 console.error('[ProfileManager] Failed to update auth store:', err);

--- a/hypertuna-worker/relay-auth-store.mjs
+++ b/hypertuna-worker/relay-auth-store.mjs
@@ -1,7 +1,4 @@
-// relay-auth-store.mjs - Token and subnet management for relay authentication
-
-import { promises as fs } from 'bare-fs';
-import { join } from 'bare-path';
+// relay-auth-store.mjs - Token management for relay authentication
 
 /**
  * In-memory store for relay authentication tokens
@@ -36,55 +33,29 @@ getAuthByToken(relayKey, token) {
    * @param {string} relayKey - Relay identifier
    * @param {string} pubkey - User public key
    * @param {string} token - Authentication token
-   * @param {string} subnetHash - Initial subnet hash
    */
-  addAuth(relayKey, pubkey, token, subnetHash = '') {
+  addAuth(relayKey, pubkey, token) {
     if (!this.relayAuths.has(relayKey)) {
       this.relayAuths.set(relayKey, new Map());
     }
-    
+
     const relayAuth = this.relayAuths.get(relayKey);
     relayAuth.set(pubkey, {
       token,
-      allowedSubnets: subnetHash ? [subnetHash] : [],
       createdAt: Date.now(),
       lastUsed: Date.now()
     });
     
     console.log(`[RelayAuthStore] Added auth for ${pubkey.substring(0, 8)}... on relay ${relayKey}`);
   }
-  
+
   /**
-   * Add a subnet to existing auth
-   * @param {string} relayKey - Relay identifier
-   * @param {string} pubkey - User public key
-   * @param {string} subnetHash - Subnet hash to add
-   * @returns {boolean} - Success
-   */
-  addSubnet(relayKey, pubkey, subnetHash) {
-    const relayAuth = this.relayAuths.get(relayKey);
-    if (!relayAuth) return false;
-    
-    const userAuth = relayAuth.get(pubkey);
-    if (!userAuth) return false;
-    
-    if (!userAuth.allowedSubnets.includes(subnetHash)) {
-      userAuth.allowedSubnets.push(subnetHash);
-      userAuth.lastUsed = Date.now();
-      console.log(`[RelayAuthStore] Added subnet for ${pubkey.substring(0, 8)}... on relay ${relayKey}`);
-    }
-    
-    return true;
-  }
-  
-  /**
-   * Verify token only (subnet is ignored)
+   * Verify a token for a relay
    * @param {string} relayKey - Relay identifier
    * @param {string} token - Auth token
-   * @param {string} [subnetHash] - Client subnet hash (ignored)
    * @returns {Object|null} - User auth data or null
    */
-  verifyAuth(relayKey, token, subnetHash) {
+  verifyAuth(relayKey, token) {
     const relayAuth = this.relayAuths.get(relayKey);
     if (!relayAuth) return null;
 


### PR DESCRIPTION
## Summary
- simplify RelayAuthStore to only track tokens
- adjust profile manager, relay manager adapter, and relay server to new API

## Testing
- `npm test --silent --prefix hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688882298ac0832abe74c8be46b35462