### PR TITLE
Remove subnet storage in relay auth

### DIFF
--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -405,15 +405,14 @@ if (workerPipe) {
               console.log('[Worker] Update auth data requested:', message.data);
               if (relayServer) {
                 try {
-                  const { relayKey, publicIdentifier, pubkey, token, subnetHashes } = message.data;
+                  const { relayKey, publicIdentifier, pubkey, token } = message.data;
                   const identifier = relayKey || publicIdentifier;
                   if (!identifier) {
                     throw new Error('No identifier provided for auth data update');
                   }
-                  const hashes = Array.isArray(subnetHashes) ? subnetHashes : (subnetHashes ? [subnetHashes] : []);
-                  const updated = await updateRelayAuthToken(identifier, pubkey, token, hashes);
+                  const updated = await updateRelayAuthToken(identifier, pubkey, token);
                   if (!updated) {
-                    queuePendingAuthUpdate(identifier, pubkey, token, hashes);
+                    queuePendingAuthUpdate(identifier, pubkey, token);
                     console.log(`[Worker] Queued pending auth update for ${identifier}`);
                   }
                   sendMessage({

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -963,9 +963,8 @@ function setupProtocolHandlers(protocol) {
       
       if (profile) {
         // Update profile with auth token
-        const { updateRelayAuthToken } = await import('./hypertuna-relay-profile-manager-bare.mjs'); 
-        // Pass subnetHash as an array to match the function signature
-        await updateRelayAuthToken(identifier, pubkey, token, [subnetHash]);
+        const { updateRelayAuthToken } = await import('./hypertuna-relay-profile-manager-bare.mjs');
+        await updateRelayAuthToken(identifier, pubkey, token);
         // Update member lists
         const currentAdds = profile.member_adds || [];
         const currentRemoves = profile.member_removes || [];
@@ -1976,7 +1975,7 @@ export async function createRelay(options) {
         
         // Persist the token to the relay's profile on disk.
         // This now adds the first auth entry.
-        const updatedProfile = await updateRelayAuthToken(result.relayKey, adminPubkey, authToken, subnetHashes);
+        const updatedProfile = await updateRelayAuthToken(result.relayKey, adminPubkey, authToken);
 
         // CRITICAL: Update the profile in the result object to ensure consistency.
         if (updatedProfile) {
@@ -2324,7 +2323,7 @@ export async function startJoinAuthentication(options) {
 
     // Persist the auth token and subnet hash to the local relay profile
     console.log(`[RelayServer] Persisting auth token for ${userPubkey.substring(0, 8)}...`);
-    await updateRelayAuthToken(relayKey, userPubkey, authToken, [requesterSubnetHash]);
+    await updateRelayAuthToken(relayKey, userPubkey, authToken);
 
     // Wait for the relay to become writable before announcing membership
     await waitForRelayWritable(relayKey);

--- a/hypertuna-worker/pending-auth.mjs
+++ b/hypertuna-worker/pending-auth.mjs
@@ -1,18 +1,18 @@
 export const pendingAuthUpdates = new Map();
 
-export function queuePendingAuthUpdate(identifier, pubkey, token, subnetHashes) {
+export function queuePendingAuthUpdate(identifier, pubkey, token) {
   if (!pendingAuthUpdates.has(identifier)) {
     pendingAuthUpdates.set(identifier, []);
   }
-  pendingAuthUpdates.get(identifier).push({ pubkey, token, subnetHashes });
+  pendingAuthUpdates.get(identifier).push({ pubkey, token });
 }
 
 export async function applyPendingAuthUpdates(updateFn, ...identifiers) {
   for (const id of identifiers) {
     const updates = pendingAuthUpdates.get(id);
     if (updates) {
-      for (const { pubkey, token, subnetHashes } of updates) {
-        await updateFn(id, pubkey, token, subnetHashes);
+      for (const { pubkey, token } of updates) {
+        await updateFn(id, pubkey, token);
       }
       pendingAuthUpdates.delete(id);
     }

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -37,11 +37,11 @@ async function setupProfile() {
 
 test('updateRelayAuthToken migrates legacy auth fields', async t => {
   const tmp = await setupLegacyProfile()
-  await updateRelayAuthToken('relay1', 'pub1', 'new', ['sub1'])
+  await updateRelayAuthToken('relay1', 'pub1', 'new')
   const profiles = await getAllRelayProfiles()
   t.is(profiles[0].auth_adds, undefined)
   t.is(profiles[0].auth_removes, undefined)
-  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', subnets: ['sub1'], ts: profiles[0].auth_config.auth_adds[0].ts }])
+  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', ts: profiles[0].auth_config.auth_adds[0].ts }])
   await fs.rm(tmp, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary
- drop subnet persistence from profile auth tokens
- sanitize auth records on load
- update pending auth helpers
- adjust worker and relay server calls
- update tests

## Testing
- `npx brittle test/*.test.js` *(fails: npm 403 due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_688884403430832abb8e5adf708139f6