### PR TITLE
Remove subnet handling from auto-connect auth import

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -557,9 +557,10 @@ export async function autoConnectStoredRelays(config) {
                             profile.auth_config.auth_adds || [],
                             profile.auth_config.auth_removes || []
                         );
-                        authorizedUsers.forEach(user => {
-                            authData[user.pubkey] = {
-                                token: user.token,
+                        // Only tokens are imported for auto-connect
+                        authorizedUsers.forEach(({ pubkey, token }) => {
+                            authData[pubkey] = {
+                                token,
                                 createdAt: Date.now(),
                                 lastUsed: Date.now()
                             };
@@ -637,9 +638,10 @@ export async function autoConnectStoredRelays(config) {
                         profile.auth_config.auth_removes || []
                     );
                     const authData = {};
-                    authorizedUsers.forEach(user => {
-                        authData[user.pubkey] = {
-                            token: user.token,
+                    // Only tokens are imported for auto-connect
+                    authorizedUsers.forEach(({ pubkey, token }) => {
+                        authData[pubkey] = {
+                            token,
                             createdAt: Date.now(),
                             lastUsed: Date.now()
                         };


### PR DESCRIPTION
## Summary
- ignore subnet info when loading auth entries in `autoConnectStoredRelays`
- keep token-based connection URLs

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888a001110832aac0966ffd6c9072b