### PR TITLE
Remove mobile QR auth flow

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1764,26 +1764,8 @@ App.syncHypertunaConfigToFile = async function() {
         document.getElementById('btn-close-auth-modal').classList.remove('hidden');
         document.getElementById('btn-cancel-auth').classList.add('hidden');
         
-        // Generate QR code for mobile authorization
-        const gatewayUrl = this.currentUser.hypertunaConfig?.gatewayUrl || HypertunaUtils.DEFAULT_GATEWAY_URL;
-        const mobileAuthUrl = `${gatewayUrl}/authorize?token=${authResult.authToken}`;
-    
-        document.getElementById('auth-url').value = mobileAuthUrl;
-        
-        // Generate QR code
-        if (window.QRCode) {
-            const qrContainer = document.getElementById('auth-qr-code');
-            qrContainer.innerHTML = ''; // Clear existing QR code
-            
-            new QRCode(qrContainer, {
-                text: mobileAuthUrl,
-                width: 200,
-                height: 200,
-                colorDark: '#000000',
-                colorLight: '#ffffff',
-                correctLevel: QRCode.CorrectLevel.H
-            });
-        }
+        // Clear any previous mobile auth info
+        document.getElementById('auth-url').value = '';
     
         // IMPORTANT: Update the user's relay list with the FULL authenticated URL
         if (this.nostr && this.nostr.client) {
@@ -1877,16 +1859,6 @@ App.syncHypertunaConfigToFile = async function() {
         });
     };
 
-    // Add QR code library dynamically if not already loaded
-    if (!window.QRCode) {
-        const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js';
-        script.onload = () => {
-            console.log('QRCode library loaded');
-        };
-        document.head.appendChild(script);
-    }
-    
     /**
      * Replace send join request method
      * Sends a join request via the nostr client


### PR DESCRIPTION
## Summary
- prune mobile QR code generation in `showAuthSuccess`
- drop helper that added `qrcode.min.js`

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in worker *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888c9fce60832ab3c837b688e43c5f