### PR TITLE
Remove qrcodejs

### DIFF
--- a/hypertuna-desktop/package.json
+++ b/hypertuna-desktop/package.json
@@ -30,7 +30,6 @@
     "bech32": "^2.0.0",
     "browserify-cipher": "^1.0.1",
     "hypercore-crypto": "^3.6.0",
-    "noble-secp256k1": "^1.2.14",
-    "qrcodejs": "^1.0.0"
+    "noble-secp256k1": "^1.2.14"
   }
 }


### PR DESCRIPTION
## Summary
- remove unused qrcodejs from desktop dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68888f5098a0832ab6386c5d9142d928