### PR TITLE
Handle null values in append

### DIFF
--- a/hypertuna-worker/hypertuna-relay-event-processor.mjs
+++ b/hypertuna-worker/hypertuna-relay-event-processor.mjs
@@ -209,9 +209,15 @@ export default class NostrRelay extends Autobee {
     console.log('[NostrRelay] APPEND OVERRIDE');
     console.log('[NostrRelay] Value:', JSON.stringify(value));
     console.log('[NostrRelay] ========================================');
+
+    // Return early if value is null or undefined
+    if (!value) {
+      console.log('[NostrRelay] append called with null value');
+      return await super.append(value);
+    }
     
     // If this is an addWriter operation, ensure we log it
-    if (value.type === 'addWriter') {
+    if (value?.type === 'addWriter') {
       console.log(`[NostrRelay] Appending addWriter operation for key: ${value.key}`);
     }
     
@@ -220,7 +226,7 @@ export default class NostrRelay extends Autobee {
       const result = await super.append(value);
       console.log('[NostrRelay] Parent append completed');
       
-      if (value.type === 'addWriter') {
+      if (value?.type === 'addWriter') {
         console.log(`[NostrRelay] addWriter operation appended successfully`);
         console.log('[NostrRelay] Triggering update to ensure new writer is recognized...');
         await this.update();


### PR DESCRIPTION
## Summary
- handle `null` payloads in `append`
- guard against missing `type` with optional chaining

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68895620f024832ab493d36124eea6db