### PR TITLE
Fix relay view readiness

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -170,6 +170,17 @@ export class RelayManager {
       // Initial update with logging
       console.log('[RelayManager] Performing initial relay update...');
       await this.relay.update();
+
+      // Wait for the underlying Hyperbee/Hyperblobs views to be ready
+      if (this.relay.view?.bee) {
+        await this.relay.view.bee.ready();
+        console.log('[RelayManager] View bee is ready');
+      }
+      if (this.relay.view?.blobs && typeof this.relay.view.blobs.ready === 'function') {
+        await this.relay.view.blobs.ready();
+        console.log('[RelayManager] View blobs are ready');
+      }
+
       console.log('[RelayManager] Initial update completed');
       
       // Log state after update

--- a/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-bare.mjs
@@ -138,6 +138,12 @@ export class RelayManager {
 
         await this.relay.update();
 
+        // Ensure the Hyperbee view is fully ready before proceeding
+        if (this.relay.view && typeof this.relay.view.ready === 'function') {
+          await this.relay.view.ready();
+          console.log('Hyperbee view is ready');
+        }
+
         this.relay.view.core.on('append', async () => {
           if (this.relay.view.version === 1) return;
           console.log('\rRelay event appended. Current version:', this.relay.view.version);


### PR DESCRIPTION
## Summary
- wait for Hyperbee and Hyperblobs views to be ready before continuing initialization
- ensure hyperbee-only manager waits for Hyperbee ready state

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688987391cf8832a9838048f894a9475