### PR TITLE
Fix peer join connection timing

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-bare.mjs
@@ -254,7 +254,9 @@ export class RelayManager {
       console.log('[RelayManager] Joining swarm with discovery key:', b4a.toString(this.relay.discoveryKey, 'hex'));
       const discovery = this.swarm.join(this.relay.discoveryKey);
       await discovery.flushed();
-      console.log('[RelayManager] Swarm joined successfully');
+      // Wait for all currently discoverable peers to connect
+      await this.swarm.flush();
+      console.log('[RelayManager] Swarm joined and flushed successfully');
   
       // Initialize relay if writable
       if (this.relay.writable) {

--- a/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-bare.mjs
+++ b/hypertuna-worker/relay-manager-hyperbee-only/hypertuna-relay-manager-bare.mjs
@@ -159,6 +159,8 @@ export class RelayManager {
         console.log('Joining swarm with discovery key:', b4a.toString(this.relay.discoveryKey, 'hex'));
         const discovery = this.swarm.join(this.relay.discoveryKey);
         await discovery.flushed();
+        await this.swarm.flush();
+        console.log('Swarm joined and flushed');
 
         console.log('Initializing relay');
         if (this.relay.writable) {


### PR DESCRIPTION
## Summary
- flush Hyperswarm swarm after joining so peers connect immediately

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889a699b9f4832ab26c9e1f402cc46f