### PR TITLE
Remove subnet tracking and join callbacks

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -519,7 +519,7 @@ class EnhancedHyperswarmPool {
   }
  }
  
- async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, subnetHash, authToken) {
+async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message, connectionKey, connectionPool, authToken) {
   try {
     console.log(`[ForwardMessage] ========================================`);
     console.log(`[ForwardMessage] FORWARDING RELAY MESSAGE`);
@@ -527,7 +527,7 @@ class EnhancedHyperswarmPool {
     console.log(`[ForwardMessage] Connection: ${connectionKey}`);
     console.log(`[ForwardMessage] Peer: ${peerPublicKey.substring(0, 8)}...`);
     console.log(`[ForwardMessage] Has auth: ${!!authToken}`);
-    console.log(`[ForwardMessage] Subnet: ${subnetHash?.substring(0, 8)}...`);
+  // No subnet information forwarded
     
     const connection = await connectionPool.getConnection(peerPublicKey);
     
@@ -535,9 +535,6 @@ class EnhancedHyperswarmPool {
     const headers = { 'content-type': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
     
     const response = await connection.sendRequest({
@@ -645,7 +642,7 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
   }
 }
  
- async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null, subnetHash = null) {
+async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null) {
   try {
     console.log(`[GetEvents] Checking for events - relay: ${relayKey}, connection: ${connectionKey}`);
     
@@ -654,9 +651,6 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
     const headers = { 'accept': 'application/json' };
     if (authToken) {
       headers['x-auth-token'] = authToken;
-    }
-    if (subnetHash) {
-      headers['x-subnet-hash'] = subnetHash;
     }
 
     const response = await connection.sendRequest({


### PR DESCRIPTION
## Summary
- drop subnet hashing utilities and related middleware
- stop storing subnet info on WebSocket connections
- simplify join requests and remove callback endpoints
- clean up registration responses and authorization handler

## Testing
- `node -c hypertuna-gateway/pear-sec-hypertuna-gateway.js`
- `node -c hypertuna-gateway/pear-sec-hypertuna-gateway-client.js`


------
https://chatgpt.com/codex/tasks/task_e_688aa344bd74832ab4a605de467b1559