### PR TITLE
Remove subnet handling from auth store

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -173,9 +173,9 @@ export async function createRelay(options = {}) {
             const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
             const authStore = getRelayAuthStore();
             
-            authStore.addAuth(relayKey, config.nostr_pubkey_hex, authToken, '');
+            authStore.addAuth(relayKey, config.nostr_pubkey_hex, authToken);
             if (publicIdentifier) {
-                authStore.addAuth(publicIdentifier, config.nostr_pubkey_hex, authToken, '');
+                authStore.addAuth(publicIdentifier, config.nostr_pubkey_hex, authToken);
             }
             
             console.log('[RelayAdapter] Added auth token to auth store');
@@ -539,7 +539,6 @@ export async function autoConnectStoredRelays(config) {
                         authorizedUsers.forEach(user => {
                             authData[user.pubkey] = {
                                 token: user.token,
-                                allowedSubnets: user.subnets || [],
                                 createdAt: Date.now(),
                                 lastUsed: Date.now()
                             };
@@ -620,7 +619,6 @@ export async function autoConnectStoredRelays(config) {
                     authorizedUsers.forEach(user => {
                         authData[user.pubkey] = {
                             token: user.token,
-                            allowedSubnets: user.subnets || [],
                             createdAt: Date.now(),
                             lastUsed: Date.now()
                         };

--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -178,16 +178,9 @@ export async function updateRelayAuthToken(identifier, pubkey, token, newSubnetH
             try {
                 const { getRelayAuthStore } = await import('./relay-auth-store.mjs');
                 const store = getRelayAuthStore();
-                const firstSubnet = newSubnetHashes[0] || '';
-                store.addAuth(profile.relay_key, pubkey, token, firstSubnet);
+                store.addAuth(profile.relay_key, pubkey, token);
                 if (profile.public_identifier) {
-                    store.addAuth(profile.public_identifier, pubkey, token, firstSubnet);
-                }
-                for (const sub of newSubnetHashes.slice(1)) {
-                    store.addSubnet(profile.relay_key, pubkey, sub);
-                    if (profile.public_identifier) {
-                        store.addSubnet(profile.public_identifier, pubkey, sub);
-                    }
+                    store.addAuth(profile.public_identifier, pubkey, token);
                 }
             } catch (err) {
                 console.error('[ProfileManager] Failed to update auth store:', err);

--- a/relay-auth-demo/demo-nostr-relay-auth.js
+++ b/relay-auth-demo/demo-nostr-relay-auth.js
@@ -148,10 +148,7 @@ server.on('request', async (req, res) => {
           const subnet = get24Subnet(normalizeIp(req.socket.remoteAddress));
           const subnetHash = sha256(subnet);
 
-          allowlist[pubkey] = {
-            token,
-            allowedSubnets: [subnetHash]
-          };
+          allowlist[pubkey] = { token };
 
           delete pendingChallenges[pubkey];
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -191,8 +188,8 @@ server.on('request', async (req, res) => {
     const mobileIp = normalizeIp(req.socket.remoteAddress);
     const subnetHash = sha256(get24Subnet(mobileIp));
     const entry = allowlist[session.pubkey];
-    if (entry && !entry.allowedSubnets.includes(subnetHash)) {
-      entry.allowedSubnets.push(subnetHash);
+    if (entry) {
+      entry.subnetHash = subnetHash;
     }
     return res.end('✅ Mobile IP authorized.');
   }


### PR DESCRIPTION
## Summary
- store fewer fields for auth entries
- drop allowedSubnets and addSubnet
- adjust worker modules to use simplified auth
- update demo to reflect new auth structure

## Testing
- `npm test` *(fails: brittle not found)*
- `npm test` in hypertuna-desktop *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aa629da6c832abd3d991359bcd069