### PR TITLE
Simplify relay auth tokens

### DIFF
--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -403,15 +403,14 @@ if (workerPipe) {
               console.log('[Worker] Update auth data requested:', message.data);
               if (relayServer) {
                 try {
-                  const { relayKey, publicIdentifier, pubkey, token, subnetHashes } = message.data;
+                  const { relayKey, publicIdentifier, pubkey, token } = message.data;
                   const identifier = relayKey || publicIdentifier;
                   if (!identifier) {
                     throw new Error('No identifier provided for auth data update');
                   }
-                  const hashes = Array.isArray(subnetHashes) ? subnetHashes : (subnetHashes ? [subnetHashes] : []);
-                  const updated = await updateRelayAuthToken(identifier, pubkey, token, hashes);
+                  const updated = await updateRelayAuthToken(identifier, pubkey, token);
                   if (!updated) {
-                    queuePendingAuthUpdate(identifier, pubkey, token, hashes);
+                    queuePendingAuthUpdate(identifier, pubkey, token);
                     console.log(`[Worker] Queued pending auth update for ${identifier}`);
                   }
                   sendMessage({

--- a/hypertuna-worker/pending-auth.mjs
+++ b/hypertuna-worker/pending-auth.mjs
@@ -1,18 +1,18 @@
 export const pendingAuthUpdates = new Map();
 
-export function queuePendingAuthUpdate(identifier, pubkey, token, subnetHashes) {
+export function queuePendingAuthUpdate(identifier, pubkey, token) {
   if (!pendingAuthUpdates.has(identifier)) {
     pendingAuthUpdates.set(identifier, []);
   }
-  pendingAuthUpdates.get(identifier).push({ pubkey, token, subnetHashes });
+  pendingAuthUpdates.get(identifier).push({ pubkey, token });
 }
 
 export async function applyPendingAuthUpdates(updateFn, ...identifiers) {
   for (const id of identifiers) {
     const updates = pendingAuthUpdates.get(id);
     if (updates) {
-      for (const { pubkey, token, subnetHashes } of updates) {
-        await updateFn(id, pubkey, token, subnetHashes);
+      for (const { pubkey, token } of updates) {
+        await updateFn(id, pubkey, token);
       }
       pendingAuthUpdates.delete(id);
     }

--- a/hypertuna-worker/test/profile-manager.test.js
+++ b/hypertuna-worker/test/profile-manager.test.js
@@ -37,11 +37,11 @@ async function setupProfile() {
 
 test('updateRelayAuthToken migrates legacy auth fields', async t => {
   const tmp = await setupLegacyProfile()
-  await updateRelayAuthToken('relay1', 'pub1', 'new', ['sub1'])
+  await updateRelayAuthToken('relay1', 'pub1', 'new')
   const profiles = await getAllRelayProfiles()
   t.is(profiles[0].auth_adds, undefined)
   t.is(profiles[0].auth_removes, undefined)
-  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', subnets: ['sub1'], ts: profiles[0].auth_config.auth_adds[0].ts }])
+  t.alike(profiles[0].auth_config.auth_adds, [{ pubkey: 'pub1', token: 'new', ts: profiles[0].auth_config.auth_adds[0].ts }])
   await fs.rm(tmp, { recursive: true, force: true })
 })
 


### PR DESCRIPTION
## Summary
- keep `authorizedUsers` entries to `{ pubkey, token }`
- update `calculateAuthorizedUsers` and `updateRelayAuthToken`
- clean helper logic that referenced subnet hashes
- adjust tests for new auth format

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688aaad0110c832a92a071c6c7cc6cd3