### PR TITLE
Remove subnet hashes from auth data updates

### DIFF
--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -1824,10 +1824,9 @@ async fetchMultipleProfiles(pubkeys) {
         event.tags.forEach(tag => {
             if (tag[0] === 'p' && tag[1]) {
                 const pubkey = tag[1];
-                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token, subnetHash]
+                const rolesAndAuthData = tag.slice(2); // e.g., ['member', token]
                 const actualRoles = [rolesAndAuthData[0]]; // 'member' or 'admin'
                 const token = rolesAndAuthData[1]; // The auth token
-                const subnetHashes = rolesAndAuthData.slice(2); // All subsequent elements are subnet hashes
 
                 // If this entry is for the current user and a token is provided
                 if (token && this.user && pubkey === this.user.pubkey) {
@@ -1849,8 +1848,7 @@ async fetchMultipleProfiles(pubkeys) {
                             relayKey,
                             publicIdentifier: groupId,
                             pubkey,
-                            token,
-                            subnetHashes 
+                            token
                         }
                     };
                     try {


### PR DESCRIPTION
## Summary
- simplify auth update by omitting subnet hashes

## Testing
- `npm test --silent` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ab105f644832a9ce65733b9c6be1c