### PR TITLE
Remove QR auth and script load

### DIFF
--- a/hypertuna-desktop/AppIntegration.js
+++ b/hypertuna-desktop/AppIntegration.js
@@ -1753,26 +1753,7 @@ App.syncHypertunaConfigToFile = async function() {
         document.getElementById('btn-close-auth-modal').classList.remove('hidden');
         document.getElementById('btn-cancel-auth').classList.add('hidden');
         
-        // Generate QR code for mobile authorization
-        const gatewayUrl = this.currentUser.hypertunaConfig?.gatewayUrl || HypertunaUtils.DEFAULT_GATEWAY_URL;
-        const mobileAuthUrl = `${gatewayUrl}/authorize?token=${authResult.authToken}`;
-    
-        document.getElementById('auth-url').value = mobileAuthUrl;
-        
-        // Generate QR code
-        if (window.QRCode) {
-            const qrContainer = document.getElementById('auth-qr-code');
-            qrContainer.innerHTML = ''; // Clear existing QR code
-            
-            new QRCode(qrContainer, {
-                text: mobileAuthUrl,
-                width: 200,
-                height: 200,
-                colorDark: '#000000',
-                colorLight: '#ffffff',
-                correctLevel: QRCode.CorrectLevel.H
-            });
-        }
+        // QRCode and mobile authorization have been removed, only show success message
     
         // IMPORTANT: Update the user's relay list with the FULL authenticated URL
         if (this.nostr && this.nostr.client) {
@@ -1841,18 +1822,7 @@ App.syncHypertunaConfigToFile = async function() {
             this.showJoinAuthModal();
         });
         
-        // Copy button for auth URL
-        document.querySelector('[data-copy="auth-url"]').addEventListener('click', function() {
-            const input = document.getElementById('auth-url');
-            input.select();
-            document.execCommand('copy');
-            
-            const originalText = this.textContent;
-            this.textContent = 'Copied!';
-            setTimeout(() => {
-                this.textContent = originalText;
-            }, 2000);
-        });
+
         
         // Click outside modal to close
         window.addEventListener('click', (e) => {
@@ -1866,16 +1836,6 @@ App.syncHypertunaConfigToFile = async function() {
         });
     };
 
-    // Add QR code library dynamically if not already loaded
-    if (!window.QRCode) {
-        const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js';
-        script.onload = () => {
-            console.log('QRCode library loaded');
-        };
-        document.head.appendChild(script);
-    }
-    
     /**
      * Replace send join request method
      * Sends a join request via the nostr client

--- a/hypertuna-desktop/index.html
+++ b/hypertuna-desktop/index.html
@@ -636,16 +636,7 @@
                     <h4>Authentication Successful!</h4>
                     <p>You now have write access to this relay.</p>
                     
-                    <!-- QR Code Section -->
-                    <div class="qr-section">
-                        <h5>Authorize Mobile Device</h5>
-                        <p>Scan this QR code with your mobile device to grant it access:</p>
-                        <div id="auth-qr-code" class="qr-container"></div>
-                        <div class="auth-url-display">
-                            <input type="text" id="auth-url" readonly class="form-input">
-                            <button class="copy-btn" data-copy="auth-url">Copy</button>
-                        </div>
-                    </div>
+
                 </div>
                 
                 <!-- Error Section (hidden initially) -->
@@ -1492,24 +1483,6 @@
       document.addEventListener('DOMContentLoaded', async () => {
         console.log('[Index] DOMContentLoaded event fired at:', new Date().toISOString());
 
-        // Pre-load QRCode library early
-        if (!window.QRCode) {
-            console.log('[Index] Pre-loading QRCode library...');
-            const script = document.createElement('script');
-            script.src = 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js';
-            script.async = true;
-            
-            script.onload = () => {
-                console.log('[Index] QRCode library pre-loaded successfully');
-            };
-            
-            script.onerror = () => {
-                console.error('[Index] Failed to pre-load QRCode library');
-            };
-            
-            document.head.appendChild(script);
-        }
-        
         // Integrate with real nostr relays FIRST, so App.init() uses the real methods
         integrateNostrRelays(App);
 

--- a/hypertuna-desktop/styles.css
+++ b/hypertuna-desktop/styles.css
@@ -1344,41 +1344,7 @@ members-list,.member-list {
     color: var(--danger);
 }
 
-.qr-section {
-    margin-top: 2rem;
-    padding-top: 2rem;
-    border-top: 1px solid var(--border);
-}
 
-.qr-section h5 {
-    margin-bottom: 0.5rem;
-}
-
-.qr-section p {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    margin-bottom: 1rem;
-}
-
-.qr-container {
-    margin: 1rem auto;
-    padding: 1rem;
-    background: white;
-    border-radius: 8px;
-    display: inline-block;
-}
-
-.auth-url-display {
-    display: flex;
-    gap: 0.5rem;
-    max-width: 400px;
-    margin: 1rem auto 0;
-}
-
-.auth-url-display input {
-    font-size: 0.85rem;
-    font-family: monospace;
-}
 
 /* Hypertuna Status Message */
 #hypertuna-key-status {


### PR DESCRIPTION
## Summary
- remove QRCode authorization from auth success flow
- drop dynamic qrcode script injection and related HTML
- delete unused QR code styles

## Testing
- `npm test` in `hypertuna-desktop` *(fails: brittle not found)*
- `npm test` in `hypertuna-worker` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ab632eecc832ab6c6a604313e0724