### PR TITLE
Remove obsolete subnet hash references

### DIFF
--- a/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
+++ b/hypertuna-worker/hypertuna-relay-profile-manager-bare.mjs
@@ -127,7 +127,7 @@ export function calculateAuthorizedUsers(auth_adds = [], auth_removes = []) {
 }
 
 // Add a function to update auth token for a user
-export async function updateRelayAuthToken(identifier, pubkey, token, newSubnetHashes = []) {
+export async function updateRelayAuthToken(identifier, pubkey, token) {
     try {
         const profile = await withProfileLock(async () => {
             let p = await getRelayProfileByKeyUnlocked(identifier);

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -758,10 +758,10 @@ function setupProtocolHandlers(protocol) {
     console.log(`[RelayServer] Join request for relay: ${identifier}`);
 
     try {
-      const body = JSON.parse(request.body.toString());
-      const { event, requesterSubnetHash, callbackUrls } = body;
-      
-      if (!event || !requesterSubnetHash) {
+    const body = JSON.parse(request.body.toString());
+      const { event } = body;
+
+      if (!event) {
         updateMetrics(false);
         return {
           statusCode: 400,
@@ -818,8 +818,7 @@ function setupProtocolHandlers(protocol) {
       const response = {
         challenge,
         relayPubkey,
-        verifyUrl: callbackUrls?.verifyUrl || `/verify-ownership`,
-        finalUrl: callbackUrls?.finalUrl || `/finalize-auth`
+        verifyUrl: `/verify-ownership`
       };
       
       updateMetrics(true);
@@ -1628,12 +1627,7 @@ async function registerWithGateway(relayProfileInfo = null) {
       console.log('[RelayServer] Gateway HTTP registration response:', response);
       console.log('[RelayServer] Registration SUCCESSFUL');
 
-      // Store subnet hash from gateway response if provided
-      if (response && response.subnetHash) {
-          config.subnetHash = response.subnetHash;
-          await saveConfig(config);
-          console.log(`[RelayServer] Stored subnet hash: ${config.subnetHash.substring(0, 8)}...`);
-      }
+
 
       // Notify parent process
       if (global.sendMessage) {


### PR DESCRIPTION
## Summary
- simplify relay join handler to stop requiring requester subnet hash
- strip subnet hash persistence during gateway registration
- drop unused subnet parameter in `updateRelayAuthToken`

## Testing
- `npx brittle test/*.test.js` *(fails: brittle not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688aa131d8d8832aad337e52c1bd0531