### PR TITLE
Simplify join authentication workflow

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -594,9 +594,7 @@ async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message
     const joinResponse = JSON.parse(response.body.toString());
     console.log(`[ForwardJoin] Response received:`, {
       hasChallenge: !!joinResponse.challenge,
-      hasRelayPubkey: !!joinResponse.relayPubkey,
-      verifyUrl: joinResponse.verifyUrl,
-      finalUrl: joinResponse.finalUrl
+      hasRelayPubkey: !!joinResponse.relayPubkey
     });
     
     console.log(`[ForwardJoin] ========================================`);
@@ -613,33 +611,6 @@ async function forwardMessageToPeerHyperswarm(peerPublicKey, identifier, message
 }
 
 // Add callback endpoint forwarding
-async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
-  try {
-    console.log(`[ForwardCallback] Forwarding ${path} to peer ${peer.publicKey.substring(0, 8)}...`);
-    
-    const connection = await connectionPool.getConnection(peer.publicKey);
-    
-    const response = await connection.sendRequest({
-      method: 'POST',
-      path: path,
-      headers: { 'content-type': 'application/json' },
-      body: Buffer.from(JSON.stringify(requestData))
-    });
-    
-    console.log(`[ForwardCallback] Response status: ${response.statusCode}`);
-    
-    if (response.statusCode !== 200) {
-      const errorBody = response.body.toString();
-      throw new Error(`Callback failed: ${errorBody}`);
-    }
-    
-    return JSON.parse(response.body.toString());
-    
-  } catch (error) {
-    console.error(`[ForwardCallback] Error:`, error.message);
-    throw error;
-  }
-}
  
 async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null) {
   try {
@@ -679,7 +650,6 @@ async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKe
   forwardRequestToPeer,
   forwardMessageToPeerHyperswarm,
   getEventsFromPeerHyperswarm,
-  forwardJoinRequestToPeer,
-  forwardCallbackToPeer
+  forwardJoinRequestToPeer
 };
  

--- a/hypertuna-gateway/pear-sec-hypertuna-gateway.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway.js
@@ -23,8 +23,7 @@ const {
   forwardRequestToPeer,
   forwardMessageToPeerHyperswarm,
   getEventsFromPeerHyperswarm,
-  forwardJoinRequestToPeer,
-  forwardCallbackToPeer
+  forwardJoinRequestToPeer
 } = require('./pear-sec-hypertuna-gateway-client');
 
 let nostrClient = null;
@@ -823,90 +822,6 @@ app.post('/register', async (req, res) => {
  * @param {string|null} initialToken - Token from GET query
  * @param {string|null} initialRelayKey - Relay key from POST body
  */
-async function processAuthorizeRequest(req, res, initialToken = null, initialRelayKey = null) {
-  console.log(`[${new Date().toISOString()}] ========================================`);
-  console.log(`[${new Date().toISOString()}] AUTHORIZE REQUEST`);
-
-  let token = initialToken;
-  let relayKey = initialRelayKey;
-
-  // If it's a POST request, try to get token/relayKey from body
-  if (req.method === 'POST' && req.body) {
-    try {
-      const body = req.body;
-      token = body.token || token;
-      relayKey = body.relayKey || relayKey;
-    } catch (e) {
-      console.warn(`[${new Date().toISOString()}] Could not parse request body for /authorize POST:`, e.message);
-    }
-  }
-
-  if (!token) {
-    console.error(`[${new Date().toISOString()}] Missing token for authorization`);
-    return res.status(400).send('<h1>Authorization Failed</h1><p>Missing token.</p>');
-  }
-
-  console.log(`[${new Date().toISOString()}] Token: ${token.substring(0, 16)}...`);
-  console.log(`[${new Date().toISOString()}] Relay: ${relayKey || 'not specified'}`);
-  // No subnet information available
-
-  try {
-    let healthyPeer = null;
-
-    if (relayKey) {
-      healthyPeer = await findHealthyPeerForRelay(relayKey);
-    } else {
-      // For QR code flow, no specific relay is known. Find any healthy peer.
-      const hyperswarmPeers = activePeers.filter(p => p && p.mode === 'hyperswarm');
-      console.log(`[${new Date().toISOString()}] Searching for any healthy peer among ${hyperswarmPeers.length} candidates...`);
-      for (const peer of hyperswarmPeers) {
-        if (peerHealthManager.isPeerHealthy(peer.publicKey)) {
-          healthyPeer = peer;
-          console.log(`[${new Date().toISOString()}] Found already healthy peer ${peer.publicKey.substring(0, 8)}`);
-          break;
-        }
-      }
-    }
-
-    if (!healthyPeer) {
-      console.error(`[${new Date().toISOString()}] No healthy peers available to process /authorize request`);
-      return res.status(503).send('<h1>Service Unavailable</h1><p>No healthy peers available to process the authorization.</p>');
-    }
-    
-    console.log(`[${new Date().toISOString()}] Selected peer for /authorize: ${healthyPeer.publicKey.substring(0, 8)}...`);
-
-    // Forward the request to the peer's /authorize endpoint
-    const result = await forwardCallbackToPeer(
-      healthyPeer,
-      '/authorize',
-      { token, relayKey },
-      connectionPool
-    );
-
-    // Respond to the client (mobile browser) with user-friendly HTML
-    if (result.success) {
-      res.status(200).send('<h1>Mobile Device Authorized</h1><p>You can now close this window.</p>');
-    } else {
-      res.status(result.statusCode || 500).send(`<h1>Authorization Failed</h1><p>${result.error || 'An unknown error occurred.'}</p>`);
-    }
-  } catch (error) {
-    console.error(`[${new Date().toISOString()}] Error processing /authorize request:`, error.message);
-    res.status(500).send(`<h1>Internal Server Error</h1><p>${error.message}</p>`);
-  }
-}
-
-// Handle GET requests for /authorize (from QR code scan)
-app.get('/authorize', async (req, res) => {
-  console.log(`[${new Date().toISOString()}] AUTHORIZE GET REQUEST (Mobile subnet via QR)`);
-  const token = req.query.token || null; // Token is in query for GET
-  await processAuthorizeRequest(req, res, token, null); // relayKey is null for QR code
-});
-
-// Handle POST requests for /authorize (if a client sends POST directly)
-app.post('/authorize', async (req, res) => {
-  console.log(`[${new Date().toISOString()}] AUTHORIZE POST REQUEST (Mobile subnet)`);
-  await processAuthorizeRequest(req, res, null, null); // Token and relayKey will be in req.body
-});
 
 
 // ============================


### PR DESCRIPTION
## Summary
- remove verify/final callback URLs from relay join response
- build `/verify-ownership` URL from gateway base when verifying
- drop unused authorize callback endpoints from gateway

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac85ef610832a95dbacc579b37bfd