### PR TITLE
Add forwardCallbackToPeer helper

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -642,7 +642,23 @@ async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKe
     console.error(`[GetEvents] Error with peer ${peerPublicKey.substring(0, 8)}:`, error.message);
     throw error;
   }
- }
+}
+
+async function forwardCallbackToPeer(peer, path, data, pool) {
+  const connection = await pool.getConnection(peer.publicKey);
+  const response = await connection.sendRequest({
+    method: 'POST',
+    path,
+    headers: { 'content-type': 'application/json' },
+    body: Buffer.from(JSON.stringify(data))
+  });
+
+  if (response.statusCode !== 200) {
+    throw new Error(`Peer returned status ${response.statusCode}`);
+  }
+
+  return JSON.parse(response.body.toString());
+}
  
  module.exports = {
   EnhancedHyperswarmPool,
@@ -650,6 +666,7 @@ async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKe
   forwardRequestToPeer,
   forwardMessageToPeerHyperswarm,
   getEventsFromPeerHyperswarm,
-  forwardJoinRequestToPeer
+  forwardJoinRequestToPeer,
+  forwardCallbackToPeer
 };
  


### PR DESCRIPTION
## Summary
- add a helper to forward callback data to a peer via HTTP
- export `forwardCallbackToPeer` from gateway client

## Testing
- `npm test` *(fails: brittle not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ad2d00034832aa0c41ff073db508f