### PR TITLE
Update relay profile defaults

### DIFF
--- a/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
+++ b/hypertuna-worker/hypertuna-relay-manager-adapter.mjs
@@ -149,6 +149,8 @@ export async function createRelay(options = {}) {
             public_identifier: publicIdentifier, // New public-facing identifier
             relay_storage: defaultStorageDir,
             created_at: new Date().toISOString(),
+            isWriter: true,
+            initialSyncComplete: true,
             auto_connect: true,
             is_active: true,
             isPublic,
@@ -352,6 +354,8 @@ export async function joinRelay(options = {}) {
                 public_identifier: publicIdentifier || null,
                 relay_storage: defaultStorageDir,
                 joined_at: new Date().toISOString(),
+                isWriter: false,
+                initialSyncComplete: false,
                 auto_connect: true,
                 is_active: true
             };


### PR DESCRIPTION
## Summary
- mark new relays as writers and synced when they are created
- mark joined relays as non-writers with sync incomplete

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c11c90d50832ab78474aec18c1fbb