### PR TITLE
docs: outline hyperdrive integration

### DIFF
--- a/hyperdrive-integration-requirements.md
+++ b/hyperdrive-integration-requirements.md
@@ -1,0 +1,60 @@
+# Hyperdrive Integration Requirements and Task Stubs
+
+## Overview
+Hypertuna peers will use a local [Hyperdrive](hyperdrive-documentation/hyperdrive-api-documentation.md) instance to share and replicate files. Hyperdrive exposes a public key (`drive.key`) identifying the drive and methods for writing and reading files such as `drive.put` and `drive.get`【F:hyperdrive-documentation/hyperdrive-api-documentation.md†L90-L100】【F:hyperdrive-documentation/hyperdrive-api-documentation.md†L134-L140】.
+
+## Functional Requirements & Tasks
+
+### 1. Worker Hyperdrive Instance
+Each worker process must create a single Hyperdrive for storing files and syncing with peers. The drive key is persisted in the user's `relay-config.json` so other peers can discover it.
+
+**Task stubs**
+- `hypertuna-worker/hyperdrive-manager.mjs`: implement `initializeHyperdrive`, `storeFile`, and `getFile` to manage a Hyperdrive rooted at `config.storage` and expose helpers for per‑relay folders【F:hypertuna-worker/hyperdrive-manager.mjs†L1-L35】.
+- `hypertuna-worker/index.js`: load `driveKey` from config and initialize Hyperdrive during startup【F:hypertuna-worker/index.js†L73-L81】【F:hypertuna-worker/index.js†L610-L621】.
+
+### 2. Config File Updates
+Persist the Hyperdrive `driveKey` in both worker and desktop configuration so that each peer can advertise its drive to others.
+
+**Task stubs**
+- Extend `loadOrCreateConfig` and related save logic to read/write `driveKey`.
+- Update desktop configuration handling to include the worker's `driveKey` in the user config file.
+
+### 3. File Publication Workflow
+When a user posts an event with a file:
+1. Desktop client hashes the file, constructs a `fileUrl` tag and sends `{ relayKey, fileHash, metadata, buffer }` to the worker.
+2. Worker stores the file under `/<relayKey>/<fileHash>` in Hyperdrive and appends an index entry to the relay database: `filekey:<hash>:drivekey:<driveKey>:pubkey:<pubkey>`.
+
+**Task stubs**
+- Desktop (`NostrIntegration.js` or related modules): add helpers to hash files, create `fileUrl` tags, and forward file data to the worker.
+- Worker (`hypertuna-relay-event-processor.mjs`): support the new `filekey:` index when processing events.
+- Worker (`hyperdrive-manager.mjs`): implement `storeFile` to persist both file data and metadata via `drive.put` and verify hash integrity.
+
+### 4. Relay-specific Folder Layout
+The Hyperdrive root must contain a subdirectory for each relay, named by the relay's `relayKey` hex string.
+
+**Task stubs**
+- `hyperdrive-manager.mjs`: ensure `initializeHyperdrive` creates the folder tree and `storeFile/getFile` reference paths like `/${relayKey}/${fileHash}`.
+
+### 5. P2P Replication & Consensus
+Peers connected to the same Nostr relay continuously reconcile their Hyperdrive subdirectory with `filekey:` entries published on the relay.
+
+**Task stubs**
+- Worker: add a periodic job to query the relay for new `filekey:` entries, fetch missing files from peers using their `driveKey`, validate hashes, and deduplicate existing files.
+- Worker: monitor local Hyperdrive for changes and keep its state in consensus with other peers.
+
+### 6. Gateway File Retrieval
+The gateway exposes an HTTPS endpoint that proxies file requests to peers via the existing protomux protocol.
+
+**Task stubs**
+- `hypertuna-gateway/pear-sec-hypertuna-gateway.js`: add a `GET /drive/:publicIdentifier/:file` handler that requests the file from a peer and streams the Hyperdrive buffer to the client.
+- `hypertuna-gateway/pear-sec-hypertuna-gateway-client.js`: implement a request method that contacts a peer and returns the requested file from its Hyperdrive.
+- Worker-side relay protocol: extend the protomux handler to respond to gateway file requests by reading from Hyperdrive using `getFile`.
+
+## Non-functional Requirements
+- Validate each replicated file’s hash against the published `fileKey` before accepting it.
+- Automatically deduplicate files in Hyperdrive.
+- Ensure Hyperdrive operations fail gracefully when storage is unavailable.
+
+## Next Steps
+Completing the above task stubs will provide a foundation for peer‑to‑peer file sharing and replication using Hyperdrive across all Hypertuna peers.
+

--- a/hypertuna-worker/hyperdrive-manager.mjs
+++ b/hypertuna-worker/hyperdrive-manager.mjs
@@ -1,0 +1,36 @@
+// hypertuna-worker/hyperdrive-manager.mjs
+// Placeholder module for Hyperdrive integration
+// TODO: Replace with real implementation using Hyperdrive and Corestore APIs.
+
+/**
+ * Initialize a Hyperdrive instance for this worker.
+ * @param {object} config - Worker configuration including storage path.
+ * @returns {Promise<void>}
+ */
+export async function initializeHyperdrive(config) {
+  // TODO: create Corestore at config.storage and open a Hyperdrive.
+  // TODO: persist the drive.key to config.driveKey so it can be shared with peers.
+}
+
+/**
+ * Store a file and its metadata under the relay's directory.
+ * @param {string} relayKey - Hex string identifying the relay.
+ * @param {string} fileHash - Hash of the file's raw data.
+ * @param {Uint8Array|Buffer} data - Raw file data.
+ * @param {object} metadata - Additional metadata (e.g. mime type).
+ */
+export async function storeFile(relayKey, fileHash, data, metadata) {
+  // TODO: write file and metadata to Hyperdrive using drive.put.
+}
+
+/**
+ * Fetch a file from the local Hyperdrive instance.
+ * @param {string} relayKey - Relay folder name.
+ * @param {string} fileHash - Identifier of the file.
+ * @returns {Promise<Uint8Array|null>}
+ */
+export async function getFile(relayKey, fileHash) {
+  // TODO: read file from Hyperdrive using drive.get.
+  return null;
+}
+

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -25,6 +25,7 @@ import {
   queuePendingAuthUpdate,
   applyPendingAuthUpdates
 } from './pending-auth.mjs';
+import { initializeHyperdrive } from './hyperdrive-manager.mjs';
 
 // In Pear, use the config.dir for the application directory
 const __dirname = Pear.config.dir || '.'
@@ -75,7 +76,8 @@ async function loadOrCreateConfig() {
     proxy_server_address: 'hypertuna.com',
     registerWithGateway: true,
     registerInterval: 300000,
-    relays: []
+    relays: [],
+    driveKey: null // TODO: populate with Hyperdrive public key
   }
 
   try {
@@ -615,6 +617,8 @@ async function main() {
 
         await loadRelayMembers();
         await loadRelayKeyMappings();
+        // TODO: initialize Hyperdrive for per-relay file storage and replication
+        await initializeHyperdrive(config);
       }
     
     if (workerPipe) {


### PR DESCRIPTION
## Summary
- document Hyperdrive-based file sharing architecture and task stubs
- scaffold a Hyperdrive manager and worker hookup for future implementation

## Testing
- `npm test` *(fails: brittle: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@noble%2fcurves)*
- `npm test` *(fails: brittle: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50f371968832a959493d732c98e2a