### PR TITLE
feat: propagate Hyperdrive key to desktop config

### DIFF
--- a/hypertuna-desktop/HypertunaUtils.js
+++ b/hypertuna-desktop/HypertunaUtils.js
@@ -308,23 +308,26 @@ export class HypertunaUtils {
      * @param {Object} config - Hypertuna configuration
      */
     static async saveConfig(config) {
+        const existing = await this.loadConfig();
+        const merged = { ...(existing || {}), ...config };
+
         ConfigLogger.log('SAVE', {
             module: 'HypertunaUtils',
             method: 'saveConfig',
             key: this.STORAGE_KEY,
-            dataSize: ConfigLogger.getDataSize(config)
+            dataSize: ConfigLogger.getDataSize(merged)
         });
-        
+
         // Save to localStorage
         try {
-            localStorage.setItem(this.STORAGE_KEY, JSON.stringify(config));
+            localStorage.setItem(this.STORAGE_KEY, JSON.stringify(merged));
             ConfigLogger.log('SAVE', {
                 module: 'HypertunaUtils',
                 method: 'saveConfig',
                 filepath: 'localStorage',
                 key: this.STORAGE_KEY,
                 success: true,
-                dataSize: ConfigLogger.getDataSize(config)
+                dataSize: ConfigLogger.getDataSize(merged)
             });
         } catch (e) {
             ConfigLogger.log('SAVE', {
@@ -342,25 +345,25 @@ export class HypertunaUtils {
             try {
                 const { promises: fs } = await import('fs');
                 const { join } = await import('path');
-                
+
                 await fs.mkdir(Pear.config.storage, { recursive: true });
                 const filePath = join(Pear.config.storage, 'relay-config.json');
-                
+
                 ConfigLogger.log('SAVE', {
                     module: 'HypertunaUtils',
                     method: 'saveConfig',
                     filepath: filePath,
-                    dataSize: ConfigLogger.getDataSize(config)
+                    dataSize: ConfigLogger.getDataSize(merged)
                 });
-                
-                await fs.writeFile(filePath, JSON.stringify(config, null, 2));
-                
+
+                await fs.writeFile(filePath, JSON.stringify(merged, null, 2));
+
                 ConfigLogger.log('SAVE', {
                     module: 'HypertunaUtils',
                     method: 'saveConfig',
                     filepath: filePath,
                     success: true,
-                    dataSize: ConfigLogger.getDataSize(config)
+                    dataSize: ConfigLogger.getDataSize(merged)
                 });
             } catch (e) {
                 ConfigLogger.log('SAVE', {
@@ -486,8 +489,12 @@ export class HypertunaUtils {
                     config.nostr_nsec = NostrUtils.hexToNsec(config.nostr_nsec_hex);
                 }
             }
+
+            if (typeof config.driveKey === 'undefined') {
+                config.driveKey = null;
+            }
         }
-        
+
         return config;
     }
     

--- a/hypertuna-desktop/app.js
+++ b/hypertuna-desktop/app.js
@@ -7,6 +7,7 @@
 import { promises as fs } from 'fs'
 import { join } from 'path'
 import { ConfigLogger } from './ConfigLogger.js';
+import { HypertunaUtils } from './HypertunaUtils.js';
 
 console.log('[App] app.js loading started at:', new Date().toISOString());
 
@@ -416,9 +417,9 @@ async function stopWorker() {
 }
 
 // Handle messages from worker
-function handleWorkerMessage(message) {
+async function handleWorkerMessage(message) {
   console.log('[App] Received worker message:', message)
-  
+
   switch (message.type) {
     case 'status':
         addLog(`Worker: ${message.message}`, 'status')
@@ -446,7 +447,26 @@ function handleWorkerMessage(message) {
                 updateWorkerStatus('running', 'Running')
         }
         break
-      
+
+    case 'drive-key':
+      try {
+        const cfg = (await HypertunaUtils.loadConfig()) || {}
+        cfg.driveKey = message.driveKey
+        await HypertunaUtils.saveConfig(cfg)
+        if (window.App && window.App.currentUser && window.App.currentUser.hypertunaConfig) {
+          window.App.currentUser.hypertunaConfig.driveKey = message.driveKey
+          if (typeof window.App.saveUserToLocalStorage === 'function') {
+            window.App.saveUserToLocalStorage()
+          }
+          if (typeof window.App.updateHypertunaDisplay === 'function') {
+            window.App.updateHypertunaDisplay()
+          }
+        }
+      } catch (e) {
+        console.error('[App] Failed to persist drive key', e)
+      }
+      break
+
     case 'heartbeat':
       // Update last heartbeat time
       updateWorkerStatus('running', `Running (${new Date(message.timestamp).toLocaleTimeString()})`)

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -85,6 +85,10 @@ async function loadOrCreateConfig(customDir = null) {
     const configData = await fs.readFile(configPath, 'utf8')
     console.log('[Worker] Loaded existing config from:', configPath)
     const loadedConfig = JSON.parse(configData)
+    if (!('driveKey' in loadedConfig)) {
+      loadedConfig.driveKey = null
+      await fs.writeFile(configPath, JSON.stringify(loadedConfig, null, 2))
+    }
     return { ...defaultConfig, ...loadedConfig }
   } catch (err) {
     console.log('[Worker] Creating new config at:', configPath)
@@ -633,6 +637,10 @@ async function main() {
       } catch (err) {
         console.error('[Worker] Failed to persist driveKey:', err);
       }
+    }
+
+    if (config.driveKey) {
+      sendMessage({ type: 'drive-key', driveKey: config.driveKey });
     }
 
     if (workerPipe) {


### PR DESCRIPTION
## Summary
- persist `driveKey` in worker relay-config and emit to desktop
- allow HypertunaUtils to load and save configurations with `driveKey`
- update desktop app to store worker `driveKey` from worker messages

## Testing
- `npm test` *(hypertuna-worker)* *(fails: brittle not found)*
- `npm install` *(hypertuna-worker)* *(fails: 403 Forbidden fetching @noble/curves)*
- `npm test` *(hypertuna-desktop)* *(fails: brittle not found)*
- `npm install` *(hypertuna-desktop)* *(fails: 403 Forbidden fetching bech32)*

------
https://chatgpt.com/codex/tasks/task_e_68c517745ab8832a982725850d3ca0dd