### PR TITLE
feat: send file buffer to worker

### DIFF
--- a/hypertuna-desktop/FileAttachmentHelper.js
+++ b/hypertuna-desktop/FileAttachmentHelper.js
@@ -1,0 +1,46 @@
+import { promises as fs } from 'fs';
+import { basename, extname } from 'path';
+import { NostrUtils } from './NostrUtils.js';
+import { HypertunaUtils } from './HypertunaUtils.js';
+
+function mimeFromExtension(ext) {
+  const map = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.mp4': 'video/mp4',
+    '.mp3': 'audio/mpeg',
+    '.pdf': 'application/pdf',
+    '.txt': 'text/plain'
+  };
+  return map[ext.toLowerCase()] || 'application/octet-stream';
+}
+
+export async function prepareFileAttachment(filePath, relayKey) {
+  const buffer = await fs.readFile(filePath);
+  const fileHash = await NostrUtils.computeSha256(buffer);
+  const ext = extname(filePath);
+  const fileId = `${fileHash}${ext}`;
+
+  let gatewayDomain;
+  try {
+    gatewayDomain = new URL(HypertunaUtils.DEFAULT_GATEWAY_URL).hostname;
+  } catch (e) {
+    gatewayDomain = HypertunaUtils.DEFAULT_GATEWAY_URL.replace(/^https?:\/\//, '');
+  }
+
+  const fileUrl = `https://${gatewayDomain}/drive/${relayKey}/${fileId}`;
+  const metadata = {
+    mimeType: mimeFromExtension(ext),
+    filename: basename(filePath)
+  };
+
+  const tags = [
+    ['r', fileUrl, 'hypertuna:drive'],
+    ['i', 'hypertuna:drive']
+  ];
+
+  return { buffer, fileHash, fileId, fileUrl, metadata, tags };
+}

--- a/hypertuna-desktop/NostrEvents.js
+++ b/hypertuna-desktop/NostrEvents.js
@@ -5,7 +5,6 @@
  */
 
 import { NostrUtils } from './NostrUtils.js';
-import { HypertunaUtils } from './HypertunaUtils.js';
 
 class NostrEvents {
     /**
@@ -128,7 +127,7 @@ class NostrEvents {
      * @param {string} privateKey - Private key for signing
      * @returns {Promise<Object>} - Signed event
      */
-    static async createTextNote(content, tags, privateKey, filePath = '') {
+    static async createTextNote(content, tags, privateKey, attachment = null, relayKey = null) {
         const eventTags = Array.isArray(tags) ? [...tags] : [];
         const urls = NostrUtils.extractUrls(content);
         for (const url of urls) {
@@ -140,31 +139,38 @@ class NostrEvents {
         let fileId = null;
         let fileDataHash = null;
         let finalContent = content;
-        if (filePath) {
-            const { promises: fs } = await import('fs');
-            const fileBuffer = await fs.readFile(filePath);
-            fileDataHash = await NostrUtils.computeSha256(fileBuffer);
-            const extPart = filePath.split('.').pop();
-            const ext = extPart && extPart !== filePath ? `.${extPart}` : '';
-            fileId = `${fileDataHash}${ext}`;
 
-            let gatewayDomain;
-            try {
-                gatewayDomain = new URL(HypertunaUtils.DEFAULT_GATEWAY_URL).hostname;
-            } catch (e) {
-                gatewayDomain = HypertunaUtils.DEFAULT_GATEWAY_URL.replace(/^https?:\/\//, '');
+        if (attachment) {
+            fileId = attachment.fileId;
+            fileDataHash = attachment.fileHash;
+            // add tags for file URL and info
+            if (Array.isArray(attachment.tags)) {
+                attachment.tags.forEach(tag => eventTags.push(tag));
             }
 
-            const publicIdentifier = eventTags.find(t => t[0] === 'h')?.[1] || '';
-            const fileUrl = `https://${gatewayDomain}/drive/${publicIdentifier}/${fileId}`;
-            eventTags.push(['r', fileUrl, 'hypertuna:drive']);
-            eventTags.push(['i', 'hypertuna:drive']);
-
-            // Append the file URL to the content so media loads in the UI
+            // ensure file URL is in content so UI can render media
             if (finalContent && !/\s$/.test(finalContent)) {
                 finalContent += ' ';
             }
-            finalContent += fileUrl;
+            finalContent += attachment.fileUrl;
+
+            // send file data to worker if available
+            if (window.workerPipe && relayKey) {
+                const msg = {
+                    type: 'upload-file',
+                    data: {
+                        relayKey,
+                        fileHash: attachment.fileHash,
+                        metadata: attachment.metadata,
+                        buffer: attachment.buffer.toString('base64')
+                    }
+                };
+                try {
+                    window.workerPipe.write(JSON.stringify(msg) + '\n');
+                } catch (err) {
+                    console.error('Failed to send upload-file message:', err);
+                }
+            }
         }
 
         const event = await this.createEvent(
@@ -185,7 +191,7 @@ class NostrEvents {
      * @param {string} privateKey - Private key for signing
      * @returns {Promise<Object>} - Signed event
      */
-    static async createGroupMessage(groupId, content, previousEvents, privateKey, filePath = '') {
+    static async createGroupMessage(groupId, content, previousEvents, privateKey, attachment = null, relayKey = null) {
         console.log(`Creating group message for group ${groupId.substring(0, 8)}...`);
         console.log(`Message content length: ${content.length}`);
         
@@ -203,7 +209,7 @@ class NostrEvents {
             });
         }
         
-        return this.createTextNote(content, tags, privateKey, filePath);
+        return this.createTextNote(content, tags, privateKey, attachment, relayKey);
     }
     
     /**

--- a/hypertuna-desktop/NostrGroupClient.js
+++ b/hypertuna-desktop/NostrGroupClient.js
@@ -8,6 +8,7 @@
 import WebSocketRelayManager from './WebSocketRelayManager.js';
 import NostrEvents from './NostrEvents.js';
 import { NostrUtils } from './NostrUtils.js';
+import { prepareFileAttachment } from './FileAttachmentHelper.js';
 
 class NostrGroupClient {
     constructor(debugMode = true) {
@@ -2629,13 +2630,25 @@ async fetchMultipleProfiles(pubkeys) {
             this.user.pubkey
         );
         
+        // Prepare file attachment if provided
+        const relayKey = this.publicToInternalMap.get(groupId) || null;
+        let attachment = null;
+        if (filePath) {
+            try {
+                attachment = await prepareFileAttachment(filePath, relayKey);
+            } catch (err) {
+                console.error('Failed to prepare file attachment:', err);
+            }
+        }
+
         // Create message event
-        const { event, fileId, fileDataHash } = await NostrEvents.createGroupMessage(
+        const { event } = await NostrEvents.createGroupMessage(
             groupId,
             content,
             previousRefs,
             this.user.privateKey,
-            filePath
+            attachment,
+            relayKey
         );
         
         // Publish only to the group's relay
@@ -2646,20 +2659,6 @@ async fetchMultipleProfiles(pubkeys) {
             throw new Error('Group relay not connected');
         }
         
-        // If a file was attached, send upload instruction to worker
-        if (fileId && window.workerPipe) {
-            const relayKey = this.publicToInternalMap.get(groupId) || null;
-            const msg = {
-                type: 'upload-file',
-                data: { relayKey, filePath, fileId, fileHash: fileDataHash }
-            };
-            try {
-                window.workerPipe.write(JSON.stringify(msg) + '\n');
-            } catch (e) {
-                console.error('Failed to send upload-file to worker', e);
-            }
-        }
-
         return event;
     }
     


### PR DESCRIPTION
## Summary
- add helper to hash files, build metadata and relay-aware file URLs
- push file attachments to worker when creating text notes
- use relay key for file tags and group message uploads

## Testing
- `npm test --prefix hypertuna-desktop` *(fails: brittle: not found)*
- `npm install --prefix hypertuna-desktop` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bech32)*


------
https://chatgpt.com/codex/tasks/task_e_68c519e4f4bc832ab1dc733d6d191e33