### PR TITLE
Deduplicate hyperdrive storeFile path

### DIFF
--- a/hypertuna-worker/hyperdrive-manager.mjs
+++ b/hypertuna-worker/hyperdrive-manager.mjs
@@ -43,7 +43,11 @@ export async function storeFile(relayKey, fileHash, data, metadata) {
   if (hash !== fileHash) {
     throw new Error('Hash mismatch')
   }
-  await drive.put(relayFilePath(relayKey, fileHash), data, { metadata })
+
+  const path = relayFilePath(relayKey, fileHash)
+  if (await drive.exists(path)) return
+
+  await drive.put(path, data, { metadata })
 }
 
 /**


### PR DESCRIPTION
## Summary
- Recompute SHA-256 of uploaded data and validate against provided hash
- Avoid duplicate storage by skipping existing entries
- Store data and metadata under relay-specific paths

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden for @noble/curves)*

------
https://chatgpt.com/codex/tasks/task_e_68c533ce8ad8832aa603d67bfbf544be