### PR TITLE
feat(worker): sync file keys over hyperdrive

### DIFF
--- a/hypertuna-worker/hyperdrive-manager.mjs
+++ b/hypertuna-worker/hyperdrive-manager.mjs
@@ -7,6 +7,10 @@ import crypto from 'bare-crypto'
 let store = null
 let drive = null
 
+export function getCorestore() {
+  return store
+}
+
 export function normalizeRelayKey(key) {
   if (!key) return ''
   if (typeof key === 'string') return key.toLowerCase()
@@ -76,5 +80,20 @@ export async function storeFile(relayKey, fileHash, data, metadata) {
 export async function getFile(relayKey, fileHash) {
   const entry = await drive.get(relayFilePath(relayKey, fileHash))
   return entry ? entry.value : null
+}
+
+export async function fetchFileFromDrive(driveKey, relayKey, fileHash) {
+  const remote = new Hyperdrive(store, driveKey)
+  await remote.ready()
+  try {
+    const entry = await remote.get(relayFilePath(relayKey, fileHash))
+    return entry ? entry.value : null
+  } catch (_) {
+    return null
+  } finally {
+    try {
+      await remote.close()
+    } catch (_) {}
+  }
 }
 

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -20,12 +20,18 @@ import {
   calculateMembers,
   calculateAuthorizedUsers
 } from './hypertuna-relay-profile-manager-bare.mjs'
-import { loadRelayKeyMappings } from './hypertuna-relay-manager-adapter.mjs'
+import { loadRelayKeyMappings, activeRelays } from './hypertuna-relay-manager-adapter.mjs'
 import {
   queuePendingAuthUpdate,
   applyPendingAuthUpdates
 } from './pending-auth.mjs';
-import { initializeHyperdrive, ensureRelayFolder } from './hyperdrive-manager.mjs';
+import {
+  initializeHyperdrive,
+  ensureRelayFolder,
+  storeFile,
+  getFile,
+  fetchFileFromDrive
+} from './hyperdrive-manager.mjs';
 
 // In Pear, use the config.dir for the application directory
 const __dirname = Pear.config.dir || '.'
@@ -37,6 +43,7 @@ let isShuttingDown = false
 const relayMembers = new Map()
 const relayMemberAdds = new Map()
 const relayMemberRemoves = new Map()
+const seenFileHashes = new Map()
 let config = null
 let configPath = null
 
@@ -197,6 +204,62 @@ async function addAuthInfoToRelays(relays) {
   } catch (err) {
     console.error('[Worker] Failed to add auth info to relays:', err)
     return relays
+  }
+}
+
+async function reconcileRelayFiles() {
+  for (const [relayKey, manager] of activeRelays.entries()) {
+    let fileMap
+    try {
+      fileMap = await manager.relay.queryFilekeyIndex()
+    } catch (err) {
+      console.error(`[Worker] Failed to query filekey index for ${relayKey}:`, err)
+      continue
+    }
+
+    const seen = seenFileHashes.get(relayKey) || new Set()
+
+    for (const [fileHash, driveMap] of fileMap.entries()) {
+      if (seen.has(fileHash)) continue
+
+      let exists = null
+      try {
+        exists = await getFile(relayKey, fileHash)
+      } catch (err) {
+        console.error(`[Worker] Error checking file ${fileHash} for relay ${relayKey}:`, err)
+      }
+
+      if (exists) {
+        console.log(`[Worker] Deduped file ${fileHash} for relay ${relayKey}`)
+        seen.add(fileHash)
+        continue
+      }
+
+      let stored = false
+      for (const [driveKey] of driveMap.entries()) {
+        for (let attempt = 0; attempt < 3 && !stored; attempt++) {
+          try {
+            const data = await fetchFileFromDrive(driveKey, relayKey, fileHash)
+            if (!data) throw new Error('File not found')
+            await storeFile(relayKey, fileHash, data, { sourceDrive: driveKey })
+            stored = true
+            break
+          } catch (err) {
+            console.error(`[Worker] Failed to download ${fileHash} from ${driveKey} (attempt ${attempt + 1}):`, err)
+          }
+        }
+        if (stored) break
+      }
+
+      if (stored) {
+        console.log(`[Worker] Stored file ${fileHash} for relay ${relayKey}`)
+        seen.add(fileHash)
+      } else {
+        console.warn(`[Worker] Unable to retrieve file ${fileHash} for relay ${relayKey}`)
+      }
+    }
+
+    seenFileHashes.set(relayKey, seen)
   }
 }
 
@@ -701,7 +764,13 @@ async function main() {
         })
       }
     }
-    
+
+    setInterval(() => {
+      if (!isShuttingDown) {
+        reconcileRelayFiles().catch(err => console.error('[Worker] File reconciliation error:', err))
+      }
+    }, 60000)
+
     // Keep the process alive with heartbeat
     const heartbeatInterval = setInterval(() => {
       if (isShuttingDown) {

--- a/hypertuna-worker/test/hyperdrive-sync.test.js
+++ b/hypertuna-worker/test/hyperdrive-sync.test.js
@@ -1,0 +1,48 @@
+import test from 'brittle'
+import fs from 'fs/promises'
+import path from 'path'
+import os from 'os'
+import crypto from 'crypto'
+import Hyperdrive from 'hyperdrive'
+
+import {
+  initializeHyperdrive,
+  ensureRelayFolder,
+  storeFile,
+  getFile,
+  fetchFileFromDrive,
+  relayPath,
+  relayFilePath,
+  getCorestore
+} from '../hyperdrive-manager.mjs'
+
+test('fetchFileFromDrive retrieves and stores file', async t => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-'))
+  global.Pear = { config: { storage: tmp } }
+  const config = { storage: tmp, relays: [] }
+  await initializeHyperdrive(config)
+
+  const store = getCorestore()
+  const remote = new Hyperdrive(store)
+  await remote.ready()
+
+  const relayKey = 'relay1'
+  await remote.mkdir(relayPath(relayKey))
+  const data = Buffer.from('hello world')
+  const hash = crypto.createHash('sha256').update(data).digest('hex')
+  await remote.put(relayFilePath(relayKey, hash), data)
+
+  const fetched = await fetchFileFromDrive(remote.key.toString('hex'), relayKey, hash)
+  t.alike(fetched, data)
+
+  await ensureRelayFolder(relayKey)
+  await storeFile(relayKey, hash, fetched, {})
+  const stored = await getFile(relayKey, hash)
+  t.alike(stored, data)
+
+  // Second store should be a no-op and not throw
+  await storeFile(relayKey, hash, fetched, {})
+
+  await remote.close()
+  await fs.rm(tmp, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary
- add hyperdrive helper to fetch files from peers and expose corestore
- periodically query connected relays for new `filekey:` entries and download unseen files
- add tests for hyperdrive file fetching and deduplication

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden - @noble/curves)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d8e7200832aa29d0adaab21cb81