### PR TITLE
feat: publish filekey events on hyperdrive changes

### DIFF
--- a/hypertuna-worker/hyperdrive-manager.mjs
+++ b/hypertuna-worker/hyperdrive-manager.mjs
@@ -97,3 +97,23 @@ export async function fetchFileFromDrive(driveKey, relayKey, fileHash) {
   }
 }
 
+export function watchDrive (onChange) {
+  if (!drive) throw new Error('Hyperdrive not initialized')
+  const watcher = drive.watch('/')
+  ;(async () => {
+    for await (const [curr, prev] of watcher) {
+      for await (const diff of curr.diff(prev)) {
+        const entry = diff.right || diff.left
+        if (!entry) continue
+        const type = diff.right && !diff.left ? 'add' : diff.left && !diff.right ? 'del' : 'update'
+        try {
+          await onChange({ type, path: entry.key })
+        } catch (err) {
+          console.error('[Hyperdrive] watch callback error:', err)
+        }
+      }
+    }
+  })().catch(err => console.error('[Hyperdrive] watch error:', err))
+  return watcher
+}
+

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -9,6 +9,7 @@ import process from 'bare-process'
 import { promises as fs } from 'bare-fs'
 import { join } from 'bare-path'
 import crypto from 'bare-crypto'
+import b4a from 'b4a'
 import {
   getAllRelayProfiles,
   getRelayProfileByKey,
@@ -53,10 +54,34 @@ let configPath = null
 let configReceived = false
 let storedParentConfig = null
 
+async function appendFilekeyDbEntry (relayKey, fileHash) {
+  if (!config?.driveKey || !config?.nostr_pubkey_hex) return
+  const relayManager = activeRelays.get(relayKey)
+  if (!relayManager?.relay) return
+
+  const fileKey = `filekey:${fileHash}:drivekey:${config.driveKey}:pubkey:${config.nostr_pubkey_hex}`
+  const fileKeyValue = {
+    filekey: fileHash,
+    drivekey: config.driveKey,
+    pubkey: config.nostr_pubkey_hex
+  }
+
+  try {
+    await relayManager.relay.put(
+      b4a.from(fileKey, 'utf8'),
+      b4a.from(JSON.stringify(fileKeyValue), 'utf8')
+    )
+    console.log(`[Worker] Stored filekey index for ${fileHash} on relay ${relayKey}`)
+  } catch (err) {
+    console.error('[Worker] Failed to store filekey index:', err)
+  }
+}
+
 async function publishFilekeyEvent (relayKey, fileHash) {
   if (!config?.nostr_pubkey_hex || !config?.nostr_nsec_hex || !config?.driveKey) return
   const relayManager = activeRelays.get(relayKey)
   if (!relayManager) return
+  await appendFilekeyDbEntry(relayKey, fileHash)
   const event = {
     kind: 1,
     content: '',

--- a/hypertuna-worker/index.js
+++ b/hypertuna-worker/index.js
@@ -30,8 +30,10 @@ import {
   ensureRelayFolder,
   storeFile,
   getFile,
-  fetchFileFromDrive
+  fetchFileFromDrive,
+  watchDrive
 } from './hyperdrive-manager.mjs';
+import { NostrUtils } from './nostr-utils.js';
 
 // In Pear, use the config.dir for the application directory
 const __dirname = Pear.config.dir || '.'
@@ -50,6 +52,63 @@ let configPath = null
 // Store configuration received from the parent process
 let configReceived = false
 let storedParentConfig = null
+
+async function publishFilekeyEvent (relayKey, fileHash) {
+  if (!config?.nostr_pubkey_hex || !config?.nostr_nsec_hex || !config?.driveKey) return
+  const relayManager = activeRelays.get(relayKey)
+  if (!relayManager) return
+  const event = {
+    kind: 1,
+    content: '',
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['filekey', fileHash],
+      ['drivekey', config.driveKey]
+    ],
+    pubkey: config.nostr_pubkey_hex
+  }
+  try {
+    const signed = await NostrUtils.signEvent(event, config.nostr_nsec_hex)
+    await relayManager.publishEvent(signed)
+    console.log(`[Worker] Published filekey event for ${fileHash} on relay ${relayKey}`)
+  } catch (err) {
+    console.error('[Worker] Failed to publish filekey event:', err)
+  }
+}
+
+async function publishFileDeletionEvent (relayKey, fileHash) {
+  if (!config?.nostr_pubkey_hex || !config?.nostr_nsec_hex || !config?.driveKey) return
+  const relayManager = activeRelays.get(relayKey)
+  if (!relayManager) return
+  const event = {
+    kind: 1,
+    content: '',
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ['filekey', fileHash],
+      ['drivekey', config.driveKey],
+      ['deleted', '1']
+    ],
+    pubkey: config.nostr_pubkey_hex
+  }
+  try {
+    const signed = await NostrUtils.signEvent(event, config.nostr_nsec_hex)
+    await relayManager.publishEvent(signed)
+    console.log(`[Worker] Published tombstone for ${fileHash} on relay ${relayKey}`)
+  } catch (err) {
+    console.error('[Worker] Failed to publish tombstone:', err)
+  }
+}
+
+function startDriveWatcher () {
+  watchDrive(async ({ type, path }) => {
+    const parts = path.split('/').filter(Boolean)
+    if (parts.length !== 2) return
+    const [relayKey, fileHash] = parts
+    if (type === 'add') await publishFilekeyEvent(relayKey, fileHash)
+    else if (type === 'del') await publishFileDeletionEvent(relayKey, fileHash)
+  })
+}
 
 
 function getUserKey(config) {
@@ -707,6 +766,8 @@ async function main() {
     if (config.driveKey) {
       sendMessage({ type: 'drive-key', driveKey: config.driveKey });
     }
+
+    startDriveWatcher()
 
     if (workerPipe) {
       sendMessage({


### PR DESCRIPTION
## Summary
- watch hyperdrive root for file additions and deletions
- publish filekey events with drive key and pubkey when new files appear
- emit tombstones for removed files

## Testing
- `npm test` *(fails: brittle: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@noble%2fcurves)*

------
https://chatgpt.com/codex/tasks/task_e_68c62012643c832a994e7ea1e0bff487