### PR TITLE
feat: stream drive files via hyperdrive

### DIFF
--- a/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway-client.js
@@ -2,7 +2,8 @@
 const Hyperswarm = require('hyperswarm');
 const crypto = require('hypercore-crypto');
 const c = require('compact-encoding');
-const RelayProtocol = require('./sushi-hypertuna-gateway-protocol.js');
+const { Readable } = require('stream');
+const RelayProtocol = require('./pear-sec-hypertuna-gateway-protocol.js');
 
 class HyperswarmConnection {
   constructor(publicKey, swarm, pool) {
@@ -639,7 +640,28 @@ async function forwardCallbackToPeer(peer, path, requestData, connectionPool) {
     throw error;
   }
 }
- 
+
+async function requestFileFromPeer(peer, identifier, file, connectionPool) {
+  try {
+    console.log(`[RequestFile] Requesting ${identifier}/${file} from peer ${peer.publicKey.substring(0, 8)}...`);
+
+    const connection = await connectionPool.getConnection(peer.publicKey);
+
+    const response = await connection.sendRequest({
+      method: 'GET',
+      path: `/drive/${identifier}/${file}`
+    });
+
+    const stream = Readable.from(response.body);
+    stream.headers = response.headers;
+    stream.statusCode = response.statusCode;
+    return stream;
+  } catch (error) {
+    console.error(`[RequestFile] Error:`, error.message);
+    throw error;
+  }
+}
+
 async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKey, connectionPool, authToken = null) {
   try {
     console.log(`[GetEvents] Checking for events - relay: ${relayKey}, connection: ${connectionKey}`);
@@ -679,6 +701,7 @@ async function getEventsFromPeerHyperswarm(peerPublicKey, relayKey, connectionKe
   forwardMessageToPeerHyperswarm,
   getEventsFromPeerHyperswarm,
   forwardJoinRequestToPeer,
-  forwardCallbackToPeer
+  forwardCallbackToPeer,
+  requestFileFromPeer
 };
  

--- a/hypertuna-gateway/pear-sec-hypertuna-gateway.js
+++ b/hypertuna-gateway/pear-sec-hypertuna-gateway.js
@@ -25,8 +25,9 @@ const {
   forwardMessageToPeerHyperswarm,
   getEventsFromPeerHyperswarm,
   forwardJoinRequestToPeer,
-  forwardCallbackToPeer
-} = require('./sushi-hypertuna-gateway-client');
+  forwardCallbackToPeer,
+  requestFileFromPeer
+} = require('./pear-sec-hypertuna-gateway-client');
 
 let nostrClient = null;
 let directoryUpdater = null;
@@ -1057,21 +1058,21 @@ app.post('/callback/finalize-auth/:identifier', async (req, res) => {
 });
 
 app.get('/drive/:identifier/:file', async (req, res) => {
-  const { identifier } = req.params;
+  const { identifier, file } = req.params;
   try {
     const peer = await findHealthyPeerForRelay(identifier);
     if (!peer) {
       return res.status(503).json({ error: 'No healthy peers available for this relay' });
     }
 
-    const response = await forwardRequestToPeer(peer, req, connectionPool);
+    const stream = await requestFileFromPeer(peer, identifier, file, connectionPool);
 
-    Object.entries(response.headers).forEach(([key, value]) => {
+    Object.entries(stream.headers).forEach(([key, value]) => {
       res.setHeader(key, value);
     });
 
-    res.status(response.statusCode);
-    Readable.from(response.body).pipe(res);
+    res.status(stream.statusCode);
+    stream.pipe(res);
 
     peer.lastSeen = Date.now();
   } catch (error) {

--- a/hypertuna-worker/pear-relay-server.mjs
+++ b/hypertuna-worker/pear-relay-server.mjs
@@ -42,6 +42,8 @@ import {
   calculateAuthorizedUsers
 } from './hypertuna-relay-profile-manager-bare.mjs';
 
+import { getFile } from './hyperdrive-manager.mjs';
+
 
 // Global state
 let config = null;
@@ -1384,13 +1386,13 @@ function setupProtocolHandlers(protocol) {
     };
   });
 
-  // Serve files from a relay's Hyperblobs storage
+  // Serve files stored in Hyperdrive
   protocol.handle('/drive/:identifier/:file', async (request) => {
     const identifier = request.params.identifier;
     const fileId = request.params.file;
-  
+
     console.log(`[RelayServer] Drive file requested: ${identifier}/${fileId}`);
-  
+
     try {
       let relayKey = identifier;
       if (identifier.includes(':')) {
@@ -1404,24 +1406,10 @@ function setupProtocolHandlers(protocol) {
           };
         }
       }
-  
-      const { activeRelays } = await import('./hypertuna-relay-manager-adapter.mjs');
-      const relayManager = activeRelays.get(relayKey);
-      if (!relayManager || !relayManager.relay) {
-        updateMetrics(false);
-        return {
-          statusCode: 404,
-          headers: { 'content-type': 'application/json' },
-          body: b4a.from(JSON.stringify({ error: 'Relay not found' }))
-        };
-      }
-  
-      // Extract hash from fileId (remove extension if present)
+
       const hash = fileId.split('.')[0];
-      console.log(`[RelayServer] Fetching blob with hash: ${hash}`);
-      
-      const blob = await relayManager.relay.getBlob(hash);
-      if (!blob || !blob.data) {
+      const fileBuffer = await getFile(relayKey, hash);
+      if (!fileBuffer) {
         updateMetrics(false);
         return {
           statusCode: 404,
@@ -1429,14 +1417,10 @@ function setupProtocolHandlers(protocol) {
           body: b4a.from(JSON.stringify({ error: 'File not found' }))
         };
       }
-  
-      console.log(`[RelayServer] Retrieved blob ${hash} (${blob.size} bytes)`);
-  
-      // Determine content type from metadata or fileId
+
+      // Determine content type from file extension
       let contentType = 'application/octet-stream';
-      if (blob.metadata?.mimeType) {
-        contentType = blob.metadata.mimeType;
-      } else if (fileId.includes('.')) {
+      if (fileId.includes('.')) {
         const ext = fileId.split('.').pop().toLowerCase();
         const mimeTypes = {
           'jpg': 'image/jpeg',
@@ -1448,18 +1432,18 @@ function setupProtocolHandlers(protocol) {
         };
         contentType = mimeTypes[ext] || contentType;
       }
-  
+
       updateMetrics(true);
       return {
         statusCode: 200,
-        headers: { 
+        headers: {
           'content-type': contentType,
-          'content-length': blob.size.toString()
+          'content-length': fileBuffer.length.toString()
         },
-        body: blob.data // Should already be a buffer
+        body: b4a.from(fileBuffer)
       };
     } catch (error) {
-      console.error('[RelayServer] Error fetching blob file:', error);
+      console.error('[RelayServer] Error fetching drive file:', error);
       updateMetrics(false);
       return {
         statusCode: 500,


### PR DESCRIPTION
## Summary
- add requestFileFromPeer to gateway client
- stream /drive requests through new client helper
- fetch drive files from hyperdrive instead of Hyperblobs

## Testing
- `npm test` *(fails: brittle not found)*
- `npm install` *(fails: 403 Forbidden @noble/curves)*

------
https://chatgpt.com/codex/tasks/task_e_68c639f4d244832aaf7f94cd778eef17